### PR TITLE
Command line options

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(yaga PRIVATE
     Yaga.cpp
     Solver.cpp
     Subsumption.cpp
+    Trail.cpp
     Theory.cpp
     Theory_combination.cpp
 )

--- a/src/Event_dispatcher.h
+++ b/src/Event_dispatcher.h
@@ -1,0 +1,124 @@
+#ifndef YAGA_EVENT_DISPATCHER_H
+#define YAGA_EVENT_DISPATCHER_H
+
+#include <vector>
+#include <ranges>
+
+#include "Event_listener.h"
+
+namespace yaga {
+
+/** Container of objects of type `Event_listener` which calls events on all registered listeners.
+ */
+class Event_dispatcher : public Event_listener {
+public:
+    virtual ~Event_dispatcher() = default;
+
+    /** Calls the on init event in all registered listeners.
+     *
+     * @param db clause database
+     * @param trail current solver trail
+     */
+    void on_init(Database& db, Trail& trail) override
+    {
+        for (auto&& listener : listeners)
+        {
+            listener->on_init(db, trail);
+        }
+    }
+
+    /** Calls the variable resize event in all registered listeners.
+     *
+     * @param type type of variables
+     * @param num_vars new number of variables
+     */
+    void on_variable_resize(Variable::Type type, int num_vars) override
+    {
+        for (auto&& listener : listeners)
+        {
+            listener->on_variable_resize(type, num_vars);
+        }
+    }
+
+    /** Calls the event in all registers listeners.
+     *
+     * @param db clause database
+     * @param trail current solver trail before backtracking
+     * @param decision_level decision level to backtrack to
+     */
+    void on_before_backtrack(Database& db, Trail& trail, int decision_level) override
+    {
+        for (auto&& listener : listeners)
+        {
+            listener->on_before_backtrack(db, trail, decision_level);
+        }
+    }
+
+    /** Calls the event in all registered listeners.
+     *
+     * @param db clause database
+     * @param trail current solver trail
+     * @param learned reference to the newly learned clause in @p db
+     */
+    void on_learned_clause(Database& db, Trail& trail, Clause const& learned) override
+    {
+        for (auto&& listener : listeners)
+        {
+            listener->on_learned_clause(db, trail, learned);
+        }
+    }
+
+    /** Calls the event in all registers listeners.
+     *
+     * @param db clause database
+     * @param trail current solver trail
+     * @param other_clause clause that is resolved with current conflict clause
+     */
+    void on_conflict_resolved(Database& db, Trail& trail, Clause const& other_clause) override
+    {
+        for (auto&& listener : listeners)
+        {
+            listener->on_conflict_resolved(db, trail, other_clause);
+        }
+    }
+
+    /** Calls the event in all registered listeners.
+     *
+     * @param db clause database
+     * @param trail current solver trail after restart
+     */
+    void on_restart(Database& db, Trail& trail) override 
+    {
+        for (auto&& listener : listeners)
+        {
+            listener->on_restart(db, trail);
+        }
+    }
+
+    /** Add @p listener to the list of listeners.
+     * 
+     * @param listener new listener to add
+     */
+    void add(Event_listener* listener) { listeners.push_back(listener); }
+
+    /** Remove @p listener from the list of listeners.
+     * 
+     * If @p listener is not registers in this dispatcher, this method does nothing.
+     * 
+     * @param listener listener to remove
+     */
+    void remove(Event_listener* listener)
+    {
+        auto it = std::ranges::find(listeners, listener);
+        if (it != listeners.end())
+        {
+            listeners.erase(it);
+        }
+    }
+private:
+    std::vector<Event_listener*> listeners;
+};
+
+}
+
+#endif // YAGA_EVENT_DISPATCHER_H

--- a/src/Options.h
+++ b/src/Options.h
@@ -1,0 +1,33 @@
+#ifndef YAGA_OPTIONS_H
+#define YAGA_OPTIONS_H
+
+#include "Bool_theory.h"
+
+namespace yaga {
+
+/** Solver options parsed from the command line.
+ */
+struct Options {
+    /** If true, the LRA plugin will decide rational variables with only one allowed value first.
+     * 
+     * For example, if 0 <= x and x <= 0 are on the trail, we will decide x before any other 
+     * variable.
+     */
+    bool prop_rational = false;
+
+    /** If true, the LRA plugin will derive new bounds using Fourier-Motzkin elimination.
+     */
+    bool deduce_bounds = false;
+
+    /** If true, the program will print solver counters like the number of conflicts.
+     */
+    bool print_stats = false;
+
+    /** Value selection strategy for boolean variables.
+     */
+    Phase phase = Phase::positive;
+};
+
+}
+
+#endif // YAGA_OPTIONS_H

--- a/src/Restart.h
+++ b/src/Restart.h
@@ -177,6 +177,20 @@ public:
         return *this;
     }
 
+    /** Set by how much does the fast average have to exceed the slow average in order to restart.
+     * 
+     * Percentage in the interval [1, inf). For example, 1.3 means we restart when the fast average
+     * exceeds the slow average by 30%.
+     * 
+     * @param value new threshold value >= 1
+     * @return this
+     */
+    inline Glucose_restart& set_threshold(float value)
+    {
+        threshold = value;
+        return *this;
+    }
+
 private:
     int countdown = 0;
     // slow moving exponential average
@@ -189,10 +203,9 @@ private:
     int fast_exp = 5;
     // minimal number of conflicts before a restart
     int min_num_conflicts = 50;
-
     // by how much does the fast average have to exceed the slow average in
     // order to restart
-    inline static float const threshold = 1.3f;
+    float threshold = 1.3f;
 
     // recompute slow/fast averages of LDBs
     inline void add_glucose(int lbd)

--- a/src/Trail.cpp
+++ b/src/Trail.cpp
@@ -1,0 +1,20 @@
+#include "Trail.h"
+#include "Event_dispatcher.h"
+
+namespace yaga {
+
+void Trail::resize(Variable::Type type, int num_vars)
+{
+    assert(type < var_models.size());
+
+    var_models[type]->resize(num_vars);
+    int num_types = std::max<int>(static_cast<int>(var_reason.size()), type + 1);
+    var_reason.resize(num_types, std::vector<Clause const*>(num_vars, nullptr));
+    var_level.resize(num_types, std::vector<int>(num_vars, unassigned));
+    var_reason[type].resize(num_vars, nullptr);
+    var_level[type].resize(num_vars, unassigned);
+    // notify all listeners that the number of variables has changed
+    dispatcher.on_variable_resize(type, num_vars);
+}
+
+}

--- a/src/Yaga.cpp
+++ b/src/Yaga.cpp
@@ -48,12 +48,6 @@ Variable Yaga::make(Variable::Type type)
 {
     auto num_vars = static_cast<int>(smt.trail().model(type).num_vars());
     smt.trail().resize(type, num_vars + 1);
-
-    // notify listeners to allocate memory for the new variable
-    for (auto listener : smt.listeners())
-    {
-        listener->on_variable_resize(type, num_vars + 1);
-    }
     return Variable{num_vars, type};
 }
 

--- a/src/Yaga.h
+++ b/src/Yaga.h
@@ -16,6 +16,7 @@
 #include "Variable_order.h"
 #include "Evsids.h"
 #include "Rational.h"
+#include "Options.h"
 
 #include <algorithm>
 #include <cassert>
@@ -31,8 +32,9 @@ public:
     /** Initialize solver with the default configuration for a specific logic
      * 
      * @param solver solver to setup
+     * @param options command line options
      */
-    virtual void setup(Solver& solver) const = 0;
+    virtual void setup(Solver& solver, Options const& options) const = 0;
 };
 
 class Propositional final : public Initializer {
@@ -42,8 +44,9 @@ public:
     /** Initialize @p solver with only the plugin for boolean variables
      * 
      * @param solver solver to initializer
+     * @param options command line options
      */
-    void setup(Solver& solver) const override;
+    void setup(Solver& solver, Options const& options) const override;
 };
 
 /** Initializer for quantifier-free linear real arithmetic.
@@ -55,8 +58,9 @@ public:
     /** Initialize @p solver with plugins for boolean variables and rational variables.
      * 
      * @param solver solver to initialize
+     * @param options command line options
      */
-    void setup(Solver& solver) const override;
+    void setup(Solver& solver, Options const& options) const override;
 };
 
 /** Predefined logic initializers for the Yaga facade.
@@ -92,16 +96,18 @@ public:
     /** Initialize the solver based on chosen logic.
      * 
      * @param init initializer for a logic
+     * @param options solver options
      */
-    explicit Yaga(Initializer const& init);
+    Yaga(Initializer const& init, Options const& options);
 
     /** Reinitialize the solver with a different logic.
      * 
      * This operation removes all clauses and variables.
      * 
      * @param init initializer for a logic
+     * @param options solver options
      */
-    void init(Initializer const& init);
+    void init(Initializer const& init, Options const& options);
 
     /** Create a new variable
      * 

--- a/src/lra/Bounds.h
+++ b/src/lra/Bounds.h
@@ -100,7 +100,7 @@ private:
     std::vector<int> updated_read;
     std::vector<int> updated_write;
     // maximum number of dependencies of a bound (as a percentage of the number of variables)
-    float threshold = 0.8;
+    float threshold = 1.0;
 
     // properties deduced from a linear constraint
     struct Deduced_properties {

--- a/src/lra/Linear_arithmetic.h
+++ b/src/lra/Linear_arithmetic.h
@@ -45,6 +45,12 @@ public:
          * Otherwise, only the first conflict is returned.
          */
         bool return_all_conflicts = true;
+
+        /** If true, the plugin will track effectively decided variables.
+         * 
+         * A rational variable is effectively decided if it can only be assigned one value.
+         */
+        bool prop_rational = false;
     };
 
     virtual ~Linear_arithmetic() = default;
@@ -165,6 +171,24 @@ public:
      */
     inline void set_options(Options const& opts) { options = opts; }
 
+    /** Check whether @p lra_var_ord can be assigned exactly one value.
+     * 
+     * @param models current (partial) assignment of variables
+     * @param lra_var_ord ordinal number of a variable
+     * @return true iff @p lra_var_ord is unassigned and it can be assigned exactly one value
+     */
+    [[nodiscard]] bool is_effectively_decided(Models const& models, int lra_var_ord);
+
+    /** Get all rational variables with only one allowed value since the last call.
+     * 
+     * @return list of rational variables that can only be assigned one value.
+     */
+    inline std::vector<int> effectively_decided()
+    {
+        auto result = std::move(decided);
+        decided.clear();
+        return result;
+    }
 private:
     struct Watched_constraint {
         // watched constraint
@@ -192,6 +216,8 @@ private:
     std::vector<std::vector<Constraint>> occur;
     // parameters of optional features
     Options options;
+    // unassigned rational variables with only one allowed value
+    std::vector<int> decided;
 
     /** Start watching LRA variables in @p cons
      *

--- a/src/parser/Parser_context.h
+++ b/src/parser/Parser_context.h
@@ -8,6 +8,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "Options.h"
 #include "Solver_answer.h"
 #include "Solver_wrapper.h"
 
@@ -125,7 +126,8 @@ public:
 
 class Parser_context {
 public:
-    explicit Parser_context(terms::Term_manager& term_manager) : term_manager(term_manager), solver(term_manager) {}
+    Parser_context(terms::Term_manager& term_manager, Options const& options) 
+        : term_manager(term_manager), solver(term_manager, options) {}
 
     void add_let_bindings(let_bindings_t&& bindings);
 

--- a/src/parser/Smt2_parser.cpp
+++ b/src/parser/Smt2_parser.cpp
@@ -92,8 +92,8 @@ class Smt2_command_context {
     void print_answer(Solver_answer answer);
 
 public:
-    Smt2_command_context(std::istream& input, std::ostream& output, terms::Term_manager& term_manager)
-        : input(input), output(output), term_parser(lexer, parser_context), parser_context(term_manager), term_manager(term_manager)
+    Smt2_command_context(std::istream& input, std::ostream& output, terms::Term_manager& term_manager, Options const& opts)
+        : input(input), output(output), term_parser(lexer, parser_context), parser_context(term_manager, opts), term_manager(term_manager)
     {}
     void execute();
 };
@@ -353,7 +353,7 @@ void Smt2_parser::parse_file(std::string const& file_name)
 void Smt2_parser::parse(std::istream& input, std::ostream& output)
 {
     terms::Term_manager tm;
-    Smt2_command_context ctx(input, output, tm);
+    Smt2_command_context ctx(input, output, tm, options);
     ctx.execute();
 }
 

--- a/src/parser/Smt2_parser.h
+++ b/src/parser/Smt2_parser.h
@@ -5,6 +5,8 @@
 #include <istream>
 #include <ostream>
 
+#include "Options.h"
+
 namespace yaga::parser {
 
 class Smt2_parser {
@@ -12,6 +14,15 @@ public:
     void parse_file(std::string const& file_name);
 
     void parse(std::istream& input, std::ostream& output);
+
+    /** Set new options
+     * 
+     * @param opts new solver options
+     */
+    inline void set_options(Options const& opts) { options = opts; }
+private:
+    // parsed command line options for the solver
+    Options options;
 };
 
 } // namespace yaga::parser

--- a/src/parser/Solver_wrapper.cpp
+++ b/src/parser/Solver_wrapper.cpp
@@ -75,8 +75,8 @@ public:
     }
 };
 
-Solver_wrapper::Solver_wrapper(terms::Term_manager& term_manager)
-    : term_manager(term_manager), solver(logic::qf_lra) {}
+Solver_wrapper::Solver_wrapper(terms::Term_manager& term_manager, Options const& opts)
+    : term_manager(term_manager), options(opts), solver(logic::qf_lra, options) {}
 
 Solver_answer Solver_wrapper::check(std::vector<term_t> const& assertions)
 {
@@ -86,7 +86,7 @@ Solver_answer Solver_wrapper::check(std::vector<term_t> const& assertions)
     }
 
     // Cnfize and assert clauses to the solver
-    solver.init(logic::qf_lra);
+    solver.init(logic::qf_lra, options);
     Internalizer_config internalizer_config{term_manager, solver};
     terms::Visitor<Internalizer_config> internalizer(term_manager, internalizer_config);
     internalizer.visit(assertions);
@@ -123,6 +123,16 @@ Solver_answer Solver_wrapper::check(std::vector<term_t> const& assertions)
     }
 
     auto res = solver.solver().check();
+
+    if (options.print_stats)
+    {
+        std::cout << "Conflicts = " << solver.solver().num_conflicts() << "\n";
+        std::cout << "Conflict clauses = " << solver.solver().num_conflict_clauses() << "\n";
+        std::cout << "Learned clauses = " << solver.solver().num_learned_clauses() << "\n";
+        std::cout << "Decisions = " << solver.solver().num_decisions() << "\n";
+        std::cout << "Restarts = " << solver.solver().num_restarts() << "\n";
+    }
+
     if (res == Solver::Result::sat)
     {
         return Solver_answer::SAT;

--- a/src/parser/Solver_wrapper.h
+++ b/src/parser/Solver_wrapper.h
@@ -41,10 +41,11 @@ public:
 class Solver_wrapper
 {
     terms::Term_manager& term_manager;
+    Options const& options;
     Yaga solver;
     std::unordered_map<terms::term_t, Variable> variables;
 public:
-    explicit Solver_wrapper(terms::Term_manager& term_manager);
+    Solver_wrapper(terms::Term_manager& term_manager, Options const& options);
 
     Solver_answer check(std::vector<terms::term_t> const& assertions);
 

--- a/src/smt_solver.cpp
+++ b/src/smt_solver.cpp
@@ -6,18 +6,77 @@
 #include <string>
 
 #include "Smt2_parser.h"
+#include "Options.h"
 
 using namespace yaga;
 
+void print_help()
+{
+    std::cerr << "Usage: ./smt [options] [input-path.smt2]" << std::endl;
+    std::cerr << "Options:\n";
+    std::cerr << "   --print-stats: print solver counters like the number of conflicts.\n";
+    std::cerr << "   --prop-rational: decide rational variables with only one allowed value first.\n";
+    std::cerr << "   --deduce-bounds: derive new bounds in LRA using Fourier-Motzkin elimination.\n";
+    std::cerr << "   --phase [positive|negative|cache]: value selection strategy for Boolean variables.\n";
+}
 
 int main(int argc, char** argv)
 {
-    if (argc != 2)
+    Options options;
+    std::string input_path;
+    for (int i = 1; i < argc; ++i)
     {
-        std::cerr << "Usage: ./smt [input-path.smt2]" << std::endl;
+        std::string arg{argv[i]};
+        if (arg == "--prop-rational")
+        {
+            options.prop_rational = true;
+        }
+        else if (arg == "--deduce-bounds")
+        {
+            options.deduce_bounds = true;
+        }
+        else if (arg == "--print-stats")
+        {
+            options.print_stats = true;
+        }
+        else if (arg == "--phase")
+        {
+            if (i + 1 < argc)
+            {
+                std::string value{argv[++i]};
+                if (value == "positive")
+                {
+                    options.phase = Phase::positive;
+                }
+                else if (value == "negative")
+                {
+                    options.phase = Phase::negative;
+                }
+                else if (value == "cache")
+                {
+                    options.phase = Phase::cache;
+                }
+            }
+        }
+        else if (arg.starts_with("-"))
+        {
+            std::cerr << "Unrecognized option: '" << arg << "'\n";
+            print_help();
+            return -1;
+        } 
+        else
+        {
+            input_path = arg;
+        }
+    }
+
+    if (input_path.empty())
+    {
+        print_help();
         return -1;
     }
 
     parser::Smt2_parser parser;
-    parser.parse_file(argv[1]);
+    parser.set_options(options);
+    parser.parse_file(input_path);
 }

--- a/src/variable_order/Variable_priority_queue.h
+++ b/src/variable_order/Variable_priority_queue.h
@@ -80,6 +80,21 @@ public:
      */
     inline bool empty() const { return pq.empty(); }
 
+    /** Get number of variables in the priority queue.
+     * 
+     * @return number of variables in the priority queue.
+     */
+    inline std::size_t size() const { return pq.size(); }
+
+    /** Get view of all variables in the priority queue
+     * 
+     * @return range of all variables in the priority queue
+     */
+    inline std::ranges::view auto vars() { 
+        return pq | std::views::transform([](auto&& node) { 
+            return node.first; 
+        }); 
+    }
 private:
     using Node = std::pair<Variable, Score>;
     using Iterator = std::vector<Node>::iterator;

--- a/tests/Conflict_analysis_test.cpp
+++ b/tests/Conflict_analysis_test.cpp
@@ -13,7 +13,8 @@ TEST_CASE("Resolve propagated literal", "[conflict_analysis]")
     Database db;
     db.assert_clause(lit(0), lit(1), lit(2));
 
-    Trail trail;
+    Event_dispatcher dispatcher;
+    Trail trail{dispatcher};
     auto& model = trail.set_model<bool>(Variable::boolean, 10);
 
     trail.decide(bool_var(0));
@@ -41,7 +42,8 @@ TEST_CASE("Add literals to conflict during resolution", "[conflict_analysis]")
     db.assert_clause(lit(0), lit(1), ~lit(2));
     db.assert_clause(lit(0), lit(2), lit(3));
 
-    Trail trail;
+    Event_dispatcher dispatcher;
+    Trail trail{dispatcher};
     auto& model = trail.set_model<bool>(Variable::boolean, 10);
 
     trail.decide(bool_var(0));
@@ -72,7 +74,8 @@ TEST_CASE("Derive a unit conflict clause", "[conflict_analysis]")
     db.assert_clause(lit(0), lit(1));
     db.assert_clause(lit(0), lit(2));
 
-    Trail trail;
+    Event_dispatcher dispatcher;
+    Trail trail{dispatcher};
     auto& model = trail.set_model<bool>(Variable::boolean, 10);
 
     trail.decide(bool_var(0));
@@ -101,7 +104,8 @@ TEST_CASE("Derive an empty clause", "[conflict_analysis]")
     db.assert_clause(~lit(0), lit(1));
     db.assert_clause(~lit(0), ~lit(1), lit(2));
 
-    Trail trail;
+    Event_dispatcher dispatcher;
+    Trail trail{dispatcher};
     auto& model = trail.set_model<bool>(Variable::boolean, 10);
 
     trail.propagate(bool_var(0), &*db.asserted().begin(), trail.decision_level());
@@ -128,7 +132,8 @@ TEST_CASE("Derive a semantic split clause", "[conflict_analysis]")
     Database db;
     db.assert_clause(~lit(0), ~lit(1), lit(2));
 
-    Trail trail;
+    Event_dispatcher dispatcher;
+    Trail trail{dispatcher};
     auto& model = trail.set_model<bool>(Variable::boolean, 10);
 
     trail.decide(bool_var(7));

--- a/tests/Glucose_restart_test.cpp
+++ b/tests/Glucose_restart_test.cpp
@@ -16,7 +16,9 @@ TEST_CASE("Restart when average of recent LBDs exceeds average of LBDs", "[gluco
     restart.set_fast_exp(2);
 
     Database db;
-    Trail trail;
+    Event_dispatcher dispatcher;
+    dispatcher.add(&restart);
+    Trail trail{dispatcher};
     trail.set_model<bool>(Variable::boolean, 9);
     trail.decide(bool_var(0));
     trail.propagate(bool_var(1), nullptr, 1);
@@ -71,7 +73,9 @@ TEST_CASE("Wait for a minimum number of conflicts before restart", "[glucose]")
     restart.set_fast_exp(2);
 
     Database db;
-    Trail trail;
+    Event_dispatcher dispatcher;
+    dispatcher.add(&restart);
+    Trail trail{dispatcher};
     trail.set_model<bool>(Variable::boolean, 9);
     trail.decide(bool_var(0));
     trail.propagate(bool_var(1), nullptr, 1);
@@ -105,7 +109,9 @@ TEST_CASE("Compute clause LBD if decision levels of literals are not consecutive
     restart.set_fast_exp(2);
 
     Database db;
-    Trail trail;
+    Event_dispatcher dispatcher;
+    dispatcher.add(&restart);
+    Trail trail{dispatcher};
     trail.set_model<bool>(Variable::boolean, 9);
     trail.decide(bool_var(0));
     trail.propagate(bool_var(1), nullptr, 1);

--- a/tests/Subsumption_test.cpp
+++ b/tests/Subsumption_test.cpp
@@ -8,15 +8,17 @@ TEST_CASE("Remove subsumed learned clauses", "[subsumption]")
     using namespace yaga;
     using namespace yaga::test;
 
-    Trail trail;
+    Subsumption s;
+    Event_dispatcher dispatcher;
+    dispatcher.add(&s);
+    Trail trail{dispatcher};
+    trail.set_model<bool>(Variable::boolean, 4);
 
     Database db;
     db.learn_clause(lit(0), lit(1), lit(2));
     db.learn_clause(lit(1), lit(2), lit(3));
     db.learn_clause(lit(1), lit(2));
 
-    Subsumption s;
-    s.on_variable_resize(Variable::boolean, 4);
     s.on_restart(db, trail);
 
     REQUIRE(db.learned().size() == 1);
@@ -32,7 +34,10 @@ TEST_CASE("Strengthen conflict clause", "[self-subsumption]")
     db.learn_clause(~lit(0), ~lit(1), lit(2));
     db.learn_clause(lit(1));
 
-    Trail trail;
+    Subsumption s;
+    Event_dispatcher dispatcher;
+    dispatcher.add(&s);
+    Trail trail{dispatcher};
     auto& model = trail.set_model<bool>(Variable::boolean, 4);
 
     model.set_value(0, false);
@@ -46,8 +51,6 @@ TEST_CASE("Strengthen conflict clause", "[self-subsumption]")
 
     auto conflict = clause(lit(0), ~lit(1), lit(2), lit(3));
 
-    Subsumption s;
-    s.on_variable_resize(Variable::boolean, 4);
     s.minimize(trail, conflict);
     REQUIRE(conflict == clause(lit(2), lit(3)));
 }

--- a/tests/bool/Bool_theory_test.cpp
+++ b/tests/bool/Bool_theory_test.cpp
@@ -13,10 +13,12 @@ TEST_CASE("Propagate unit clauses if the trail is empty", "[bool_theory][bcp]")
     db.assert_clause(~lit(0));
     db.assert_clause(~lit(1));
 
-    Trail trail;
+    Bool_theory theory;
+    Event_dispatcher dispatcher;
+    dispatcher.add(&theory);
+    Trail trail{dispatcher};
     auto& model = trail.set_model<bool>(Variable::boolean, 10);
 
-    Bool_theory theory;
     auto conflicts = theory.propagate(db, trail);
     REQUIRE(conflicts.empty());
     
@@ -43,14 +45,15 @@ TEST_CASE("Run BCP after a value is decided", "[bool_theory][bcp]")
     using namespace yaga;
     using namespace yaga::test;
 
-    Bool_theory theory;
-
     Database db;
     db.assert_clause(lit(0), lit(1));
     db.assert_clause(~lit(0), ~lit(2));
     db.assert_clause(lit(0), lit(3));
 
-    Trail trail;
+    Bool_theory theory;
+    Event_dispatcher dispatcher;
+    dispatcher.add(&theory);
+    Trail trail{dispatcher};
     auto& model = trail.set_model<bool>(Variable::boolean, 10);
 
     // initialize watch lists
@@ -92,14 +95,15 @@ TEST_CASE("Run BCP after backtracking", "[bool_theory][bcp]")
     using namespace yaga;
     using namespace yaga::test;
 
-    Bool_theory theory;
-
     Database db;
     db.assert_clause(lit(0), lit(1));
     db.assert_clause(~lit(0));
     db.assert_clause(~lit(1), ~lit(2), lit(3));
 
-    Trail trail;
+    Bool_theory theory;
+    Event_dispatcher dispatcher;
+    dispatcher.add(&theory);
+    Trail trail{dispatcher};
     auto& model = trail.set_model<bool>(Variable::boolean, 10);
 
     // init
@@ -134,13 +138,14 @@ TEST_CASE("Skip satisfied clauses", "[bool_theory][bcp]")
     using namespace yaga;
     using namespace yaga::test;
 
-    Bool_theory theory;
-
     Database db;
     db.assert_clause(lit(0), lit(1));
     db.assert_clause(~lit(0), lit(1), lit(2));
 
-    Trail trail;
+    Bool_theory theory;
+    Event_dispatcher dispatcher;
+    dispatcher.add(&theory);
+    Trail trail{dispatcher};
     auto& model = trail.set_model<bool>(Variable::boolean, 10);
 
     auto conflicts = theory.propagate(db, trail);
@@ -177,9 +182,11 @@ TEST_CASE("Maintain watched literals invariants", "[bool_theory][bcp]")
     using namespace yaga;
     using namespace yaga::test;
 
-    Bool_theory theory;
     Database db;
-    Trail trail;
+    Bool_theory theory;
+    Event_dispatcher dispatcher;
+    dispatcher.add(&theory);
+    Trail trail{dispatcher};
     auto& model = trail.set_model<bool>(Variable::boolean, 10);
 
     SECTION("move true literals to the front")

--- a/tests/lra/Linear_arithmetic_test.cpp
+++ b/tests/lra/Linear_arithmetic_test.cpp
@@ -53,11 +53,13 @@ TEST_CASE("Propagate in an empty trail", "[linear_arithmetic]")
     using namespace yaga::test;
 
     Database db;
-    Trail trail;
+    Linear_arithmetic lra;
+    Event_dispatcher dispatcher;
+    dispatcher.add(&lra);
+    Trail trail{dispatcher};
     trail.set_model<bool>(Variable::boolean, 0);
     trail.set_model<Rational>(Variable::rational, 10);
-    Linear_arithmetic lra;
-    lra.on_variable_resize(Variable::rational, 10);
+
     auto conflicts = lra.propagate(db, trail);
     REQUIRE(conflicts.empty());
     REQUIRE(trail.empty());
@@ -69,11 +71,13 @@ TEST_CASE("Propagate unit constraints on the trail", "[linear_arithmetic]")
     using namespace yaga::test;
 
     Database db;
-    Trail trail;
+    Linear_arithmetic lra;
+    Event_dispatcher dispatcher;
+    dispatcher.add(&lra);
+    Trail trail{dispatcher};
     trail.set_model<bool>(Variable::boolean, 0);
     trail.set_model<Rational>(Variable::rational, 3);
-    Linear_arithmetic lra;
-    lra.on_variable_resize(Variable::rational, 3);
+
     auto models = lra.relevant_models(trail);
     auto lin = factory(lra, trail);
     auto [x, y, z] = real_vars<3>();
@@ -96,11 +100,13 @@ TEST_CASE("Propagate unit constraints over multiple decision levels", "[linear_a
     using namespace yaga::test;
 
     Database db;
-    Trail trail;
+    Linear_arithmetic lra;
+    Event_dispatcher dispatcher;
+    dispatcher.add(&lra);
+    Trail trail{dispatcher};
     trail.set_model<bool>(Variable::boolean, 0);
     trail.set_model<Rational>(Variable::rational, 3);
-    Linear_arithmetic lra;
-    lra.on_variable_resize(Variable::rational, 3);
+
     auto models = lra.relevant_models(trail);
     auto linear = factory(lra, trail);
     auto [x, y, z] = real_vars<3>();
@@ -146,11 +152,13 @@ TEST_CASE("LRA propagation is idempotent", "[linear_arithmetic]")
     using namespace yaga::test;
 
     Database db;
-    Trail trail;
+    Linear_arithmetic lra;
+    Event_dispatcher dispatcher;
+    dispatcher.add(&lra);
+    Trail trail{dispatcher};
     trail.set_model<bool>(Variable::boolean, 0);
     trail.set_model<Rational>(Variable::rational, 3);
-    Linear_arithmetic lra;
-    lra.on_variable_resize(Variable::rational, 3);
+
     auto linear = factory(lra, trail);
     auto [x, y, z] = real_vars<3>();
 
@@ -176,11 +184,13 @@ TEST_CASE("Propagate fully assigned constraints in the system", "[linear_arithme
     using namespace yaga::test;
 
     Database db;
-    Trail trail;
+    Linear_arithmetic lra;
+    Event_dispatcher dispatcher;
+    dispatcher.add(&lra);
+    Trail trail{dispatcher};
     trail.set_model<bool>(Variable::boolean, 0);
     trail.set_model<Rational>(Variable::rational, 3);
-    Linear_arithmetic lra;
-    lra.on_variable_resize(Variable::rational, 3);
+
     auto models = lra.relevant_models(trail);
     auto linear = factory(lra, trail);
     auto [x, y, z] = real_vars<3>();
@@ -211,11 +221,13 @@ TEST_CASE("Compute bounds correctly after backtracking", "[linear_arithmetic]")
     using namespace yaga::test;
 
     Database db;
-    Trail trail;
+    Linear_arithmetic lra;
+    Event_dispatcher dispatcher;
+    dispatcher.add(&lra);
+    Trail trail{dispatcher};
     trail.set_model<bool>(Variable::boolean, 0);
     trail.set_model<Rational>(Variable::rational, 3);
-    Linear_arithmetic lra;
-    lra.on_variable_resize(Variable::rational, 3);
+
     auto models = lra.relevant_models(trail);
     auto linear = factory(lra, trail);
     auto [x, y, z] = real_vars<3>();
@@ -246,11 +258,13 @@ TEST_CASE("Detect a bound conflict", "[linear_arithmetic]")
     using namespace yaga::test;
 
     Database db;
-    Trail trail;
+    Linear_arithmetic lra;
+    Event_dispatcher dispatcher;
+    dispatcher.add(&lra);
+    Trail trail{dispatcher};
     trail.set_model<bool>(Variable::boolean, 0);
     trail.set_model<Rational>(Variable::rational, 3);
-    Linear_arithmetic lra;
-    lra.on_variable_resize(Variable::rational, 3);
+
     auto models = lra.relevant_models(trail);
     auto linear = factory(lra, trail);
     auto [x, y, z] = real_vars<3>();
@@ -384,11 +398,13 @@ TEST_CASE("Detect trivial bound conflict with several variables", "[linear_arith
     using namespace yaga::test;
 
     Database db;
-    Trail trail;
+    Linear_arithmetic lra;
+    Event_dispatcher dispatcher;
+    dispatcher.add(&lra);
+    Trail trail{dispatcher};
     trail.set_model<bool>(Variable::boolean, 0);
     trail.set_model<Rational>(Variable::rational, 2);
-    Linear_arithmetic lra;
-    lra.on_variable_resize(Variable::rational, 2);
+
     auto linear = factory(lra, trail);
     auto [x, y] = real_vars<2>();
 
@@ -407,11 +423,13 @@ TEST_CASE("Detect trivial inequality conflict with several variables", "[linear_
     using namespace yaga::test;
 
     Database db;
-    Trail trail;
+    Linear_arithmetic lra;
+    Event_dispatcher dispatcher;
+    dispatcher.add(&lra);
+    Trail trail{dispatcher};
     trail.set_model<bool>(Variable::boolean, 0);
     trail.set_model<Rational>(Variable::rational, 2);
-    Linear_arithmetic lra;
-    lra.on_variable_resize(Variable::rational, 2);
+
     auto linear = factory(lra, trail);
     auto [x, y] = real_vars<2>();
 
@@ -431,12 +449,13 @@ TEST_CASE("Always choose a new boolean variable for unique derived constraints",
     using namespace yaga::test;
 
     Database db;
-    Trail trail;
+    Linear_arithmetic lra;
+    Event_dispatcher dispatcher;
+    dispatcher.add(&lra);
+    Trail trail{dispatcher};
     trail.set_model<bool>(Variable::boolean, 1);
     trail.set_model<Rational>(Variable::rational, 3);
-    Linear_arithmetic lra;
-    lra.on_variable_resize(Variable::rational, 3);
-    lra.on_variable_resize(Variable::boolean, 1);
+
     auto models = lra.relevant_models(trail);
     auto linear = factory(lra, trail);
     auto [x, y] = real_vars<2>();
@@ -460,11 +479,13 @@ TEST_CASE("Detect an inequality conflict", "[linear_arithmetic]")
     using namespace yaga::test;
 
     Database db;
-    Trail trail;
+    Linear_arithmetic lra;
+    Event_dispatcher dispatcher;
+    dispatcher.add(&lra);
+    Trail trail{dispatcher};
     trail.set_model<bool>(Variable::boolean, 0);
     trail.set_model<Rational>(Variable::rational, 3);
-    Linear_arithmetic lra;
-    lra.on_variable_resize(Variable::rational, 3);
+
     auto models = lra.relevant_models(trail);
     auto linear = factory(lra, trail);
     auto [x, y, z] = real_vars<3>();
@@ -549,11 +570,13 @@ TEST_CASE("Backtrack-decide a constraint", "[linear_arithmetic]")
     using namespace yaga::test;
 
     Database db;
-    Trail trail;
+    Linear_arithmetic lra;
+    Event_dispatcher dispatcher;
+    dispatcher.add(&lra);
+    Trail trail{dispatcher};
     trail.set_model<bool>(Variable::boolean, 0);
     trail.set_model<Rational>(Variable::rational, 2);
-    Linear_arithmetic lra;
-    lra.on_variable_resize(Variable::rational, trail.model<Rational>(Variable::rational).num_vars());
+
     auto models = lra.relevant_models(trail);
     auto linear = factory(lra, trail);
     auto [x, y] = real_vars<2>();
@@ -582,11 +605,13 @@ TEST_CASE("Propagate derived bound constraint semantically only if it is not on 
     using namespace yaga::test;
 
     Database db;
-    Trail trail;
+    Linear_arithmetic lra;
+    Event_dispatcher dispatcher;
+    dispatcher.add(&lra);
+    Trail trail{dispatcher};
     trail.set_model<bool>(Variable::boolean, 0);
     trail.set_model<Rational>(Variable::rational, 2);
-    Linear_arithmetic lra;
-    lra.on_variable_resize(Variable::rational, trail.model<Rational>(Variable::rational).num_vars());
+
     auto linear = factory(lra, trail);
     auto [x, y] = real_vars<2>();
 
@@ -606,11 +631,13 @@ TEST_CASE("Propagate derived inequality constraint semantically only if it is no
     using namespace yaga::test;
 
     Database db;
-    Trail trail;
+    Linear_arithmetic lra;
+    Event_dispatcher dispatcher;
+    dispatcher.add(&lra);
+    Trail trail{dispatcher};
     trail.set_model<bool>(Variable::boolean, 0);
     trail.set_model<Rational>(Variable::rational, 2);
-    Linear_arithmetic lra;
-    lra.on_variable_resize(Variable::rational, trail.model<Rational>(Variable::rational).num_vars());
+
     auto linear = factory(lra, trail);
     auto [x, y] = real_vars<2>();
 
@@ -651,11 +678,13 @@ TEST_CASE("The first two unassigned variables in a derived constraint have the h
     using namespace yaga::test;
 
     Database db;
-    Trail trail;
+    Linear_arithmetic lra;
+    Event_dispatcher dispatcher;
+    dispatcher.add(&lra);
+    Trail trail{dispatcher};
     trail.set_model<bool>(Variable::boolean, 0);
     trail.set_model<Rational>(Variable::rational, 3);
-    Linear_arithmetic lra;
-    lra.on_variable_resize(Variable::rational, trail.model<Rational>(Variable::rational).num_vars());
+
     auto linear = factory(lra, trail);
     auto [x, y, z] = real_vars<3>();
 
@@ -684,11 +713,13 @@ TEST_CASE("Decide variable", "[linear_arithmetic]")
     using namespace yaga::literals;
 
     Database db;
-    Trail trail;
+    Linear_arithmetic lra;
+    Event_dispatcher dispatcher;
+    dispatcher.add(&lra);
+    Trail trail{dispatcher};
     trail.set_model<bool>(Variable::boolean, 0);
     trail.set_model<Rational>(Variable::rational, 3);
-    Linear_arithmetic lra;
-    lra.on_variable_resize(Variable::rational, trail.model<Rational>(Variable::rational).num_vars());
+
     auto linear = factory(lra, trail);
     auto models = lra.relevant_models(trail);
 

--- a/tests/lra/Lra_conflict_analysis_test.cpp
+++ b/tests/lra/Lra_conflict_analysis_test.cpp
@@ -13,11 +13,12 @@ TEST_CASE("FM elimination", "[fm]")
 
     constexpr int num_reals = 5;
 
-    Trail trail;
+    Linear_arithmetic lra;
+    Event_dispatcher dispatcher;
+    dispatcher.add(&lra);
+    Trail trail{dispatcher};
     trail.set_model<bool>(Variable::boolean, 0);
     trail.set_model<Rational>(Variable::rational, num_reals);
-    Linear_arithmetic lra;
-    lra.on_variable_resize(Variable::rational, num_reals);
     auto [x, y, z, w, a] = real_vars<num_reals>();
     auto make = factory(lra, trail);
     auto models = lra.relevant_models(trail);
@@ -141,11 +142,13 @@ TEST_CASE("Derive bound conflict when some variables are not assigned", "[bound_
 
     constexpr int num_reals = 5;
 
-    Trail trail;
+    Linear_arithmetic lra;
+    Event_dispatcher dispatcher;
+    dispatcher.add(&lra);
+    Trail trail{dispatcher};
     trail.set_model<bool>(Variable::boolean, 0);
     trail.set_model<Rational>(Variable::rational, num_reals);
-    Linear_arithmetic lra;
-    lra.on_variable_resize(Variable::rational, num_reals);
+
     Bounds bounds;
     bounds.resize(num_reals);
     auto [x, y, z, a, b] = real_vars<num_reals>();
@@ -203,11 +206,12 @@ TEST_CASE("Derive inequality conflict when some variables are not assigned", "[i
 
     constexpr int num_reals = 7;
 
-    Trail trail;
+    Linear_arithmetic lra;
+    Event_dispatcher dispatcher;
+    dispatcher.add(&lra);
+    Trail trail{dispatcher};
     trail.set_model<bool>(Variable::boolean, 0);
     trail.set_model<Rational>(Variable::rational, num_reals);
-    Linear_arithmetic lra;
-    lra.on_variable_resize(Variable::rational, num_reals);
     Bounds bounds;
     bounds.resize(num_reals);
     auto [x, y, z, w, a, b, c] = real_vars<num_reals>();

--- a/tests/lra/Lra_test.cpp
+++ b/tests/lra/Lra_test.cpp
@@ -147,7 +147,8 @@ TEST_CASE("Check a satisfiable LRA formula parsed from SMTLIB", "[lra][unsat][in
     input << "(declare-fun pi () Real)\n";
     input << "(assert (and (> pi (/ 15707963 5000000)) (and (not (<= (/ 31415927 10000000) pi)) (and (<= skoY (* pi (/ 1 3))) (and (<= (* pi (/ 1 4)) skoY) (and (<= skoX 120) (<= 100 skoX)))))))\n";
 
-    Yaga smt{logic::qf_lra};
+    Options opts;
+    Yaga smt{logic::qf_lra, opts};
     Smtlib_parser<Direct_interpreter> parser{smt};
     parser.parse(input);
 
@@ -176,7 +177,8 @@ TEST_CASE("Check an unsatisfiable LRA formula parsed from SMTLIB", "[lra][unsat]
     input << "(declare-fun pi () Real)\n";
     input << "(assert (and (= skoX 0) (and (not (<= pi (/ 15707963 5000000))) (and (not (<= (/ 31415927 10000000) pi)) (and (<= skoY (* pi (/ 1 3))) (and (<= (* pi (/ 1 4)) skoY) (and (<= skoX 120) (<= 100 skoX))))))))\n";
 
-    Yaga smt{logic::qf_lra};
+    Options opts;
+    Yaga smt{logic::qf_lra, opts};
     Smtlib_parser<Direct_interpreter> parser{smt};
     parser.parse(input);
 

--- a/tests/lra/Smtlib_parser_test.cpp
+++ b/tests/lra/Smtlib_parser_test.cpp
@@ -312,7 +312,7 @@ TEST_CASE("Parse boolean functions", "[test_parser]")
         REQUIRE(test.answer() == Solver_answer::SAT);
         REQUIRE(test.boolean("b1").has_value());
         REQUIRE(test.boolean("b2").has_value());
-        REQUIRE((*test.boolean("b1") || *test.boolean("b2")));
+        REQUIRE(!(*test.boolean("b1") && *test.boolean("b2")));
     }
 
     SECTION("non-negated binary or")

--- a/tests/variable_order/Evsids_test.cpp
+++ b/tests/variable_order/Evsids_test.cpp
@@ -11,8 +11,8 @@ TEST_CASE("Pick a variable with empty clause database", "[evsids]")
     using namespace yaga::test;
 
     Database db;
-
-    Trail trail;
+    Event_dispatcher dispatcher;
+    Trail trail{dispatcher};
     auto& model = trail.set_model<bool>(Variable::boolean, 3);
 
     Evsids evsids;
@@ -47,7 +47,8 @@ TEST_CASE("Pick the most used variable if there has not been a conflict", "[evsi
     db.assert_clause(lit(0), ~lit(1));
     db.assert_clause(lit(0));
 
-    Trail trail;
+    Event_dispatcher dispatcher;
+    Trail trail{dispatcher};
     auto& model = trail.set_model<bool>(Variable::boolean, 3);
 
     Evsids evsids;
@@ -82,7 +83,8 @@ TEST_CASE("Pick a variable after a large number of score decays", "[evsids]")
     db.assert_clause(lit(0), ~lit(1));
     db.assert_clause(lit(0));
 
-    Trail trail;
+    Event_dispatcher dispatcher;
+    Trail trail{dispatcher};
     auto& model = trail.set_model<bool>(Variable::boolean, 3);
 
     Evsids evsids;

--- a/tests/variable_order/Generalized_vsids_test.cpp
+++ b/tests/variable_order/Generalized_vsids_test.cpp
@@ -9,19 +9,16 @@ TEST_CASE("Pick a variable with empty database", "[generalized_vsids]")
     using namespace yaga::test;
 
     Database db;
-
-    Trail trail;
-    auto& bool_model = trail.set_model<bool>(Variable::boolean, 3);
-    auto& real_model = trail.set_model<Rational>(Variable::rational, 2);
-
     Linear_arithmetic lra;
-    lra.on_variable_resize(Variable::boolean, bool_model.num_vars());
-    lra.on_variable_resize(Variable::rational, real_model.num_vars());
-
     Generalized_vsids vsids{lra};
-    vsids.on_variable_resize(Variable::boolean, bool_model.num_vars());
-    vsids.on_variable_resize(Variable::rational, real_model.num_vars());
-    vsids.on_init(db, trail);
+    Event_dispatcher dispatcher;
+    dispatcher.add(&lra);
+    dispatcher.add(&vsids);
+    Trail trail{dispatcher};
+    trail.set_model<bool>(Variable::boolean, 3);
+    trail.set_model<Rational>(Variable::rational, 2);
+
+    dispatcher.on_init(db, trail);
 
     auto res = vsids.pick(db, trail);
     REQUIRE(res.value() == Variable{0, Variable::boolean});
@@ -53,24 +50,22 @@ TEST_CASE("pick the most used variable at the start", "[generalized_vsids]")
     using namespace yaga::test;
 
     Database db;
-
-    Trail trail;
-    auto& bool_model = trail.set_model<bool>(Variable::boolean, 0);
-    auto& real_model = trail.set_model<Rational>(Variable::rational, 2);
-
     Linear_arithmetic lra;
-    lra.on_variable_resize(Variable::boolean, bool_model.num_vars());
-    lra.on_variable_resize(Variable::rational, real_model.num_vars());
+    Generalized_vsids vsids{lra};
+    Event_dispatcher dispatcher;
+    dispatcher.add(&lra);
+    dispatcher.add(&vsids);
+    Trail trail{dispatcher};
+    trail.set_model<bool>(Variable::boolean, 0);
+    trail.set_model<Rational>(Variable::rational, 2);
+
     auto linear = factory(lra, trail);
     auto [x, y] = real_vars<2>();
 
     db.assert_clause(clause(~linear(x < y), linear(y == 0)));
     db.assert_clause(clause(linear(x < y), linear(x == 0)));
 
-    Generalized_vsids vsids{lra};
-    vsids.on_variable_resize(Variable::boolean, bool_model.num_vars());
-    vsids.on_variable_resize(Variable::rational, real_model.num_vars());
-    vsids.on_init(db, trail);
+    dispatcher.on_init(db, trail);
 
     auto res = vsids.pick(db, trail);
     REQUIRE(res.value() == x);


### PR DESCRIPTION
The intent is to add command line options for the SMT program and some missing documentation.
- The SMT solver program now has optional parameters to enable heuristics that might not be beneficial in all situations (phase-saving, propagation of rational variables with only one allowed value, and derivation of new bounds in LRA).
- `trail.resize()` now triggers the `on_variable_resized` event. Previously, new variables could be added only during a conflict, which is sufficient for LRA. However, other plugins may need to add new variables more frequently. 
