### PR TITLE
Rationals: Fix smt-lib print format

### DIFF
--- a/src/lra/Long_fraction.cpp
+++ b/src/lra/Long_fraction.cpp
@@ -90,7 +90,7 @@ namespace yaga {
             assert(mpqPartValid());
             mpq_class mpq_c(mpq);
             if (sign) mpq_c = -mpq_c;
-            out << (sign ? "(- " : "") << mpq_c << (sign ? ")" : "");
+            out << "(/ " << (sign ? "(- " : "") << mpq_c.get_num() << (sign ? ") " : " ") << mpq_c.get_den() << ")";
         }
     }
 


### PR DESCRIPTION
Previously, a rational value that requires the GMP representation would be printed in the model as "1/12003000000" instead of the correct SMT-LIB format "(/ 1 12003000000)"