### PR TITLE
Fix duplicate detection in Solver::learn()

### DIFF
--- a/src/Literal.h
+++ b/src/Literal.h
@@ -45,6 +45,15 @@ public:
      */
     inline bool operator!=(Literal const& other) const { return !operator==(other); }
 
+    /** Three-way comparison of two literals.
+     * 
+     * @param other other literal
+     * @return value < 0 if this literal is less than @p other
+     * @return value > 0 if this literal is greater than @p other
+     * @return value == 0 if this literal is equal to @p other
+     */
+    inline int operator<=>(Literal const& other) const { return value - other.value; }
+
     /** Get negation of this literal
      *
      * @return new literal which represents negation of this literal

--- a/src/Literal.h
+++ b/src/Literal.h
@@ -52,7 +52,10 @@ public:
      * @return value > 0 if this literal is greater than @p other
      * @return value == 0 if this literal is equal to @p other
      */
-    inline int operator<=>(Literal const& other) const { return value - other.value; }
+    inline int operator<=>(Literal const& other) const 
+    { 
+        return index() - other.index(); 
+    }
 
     /** Get negation of this literal
      *
@@ -84,6 +87,12 @@ public:
 private:
     // `variable ordinal + 1`, negative value indicates negative literal
     int value;
+
+    /** Generate an index of this literal s.t. literal and its negation are next to each other.
+     * 
+     * @return a positive integer identifying this literal
+     */
+    inline int index() const { return var().ord() * 2 + (is_negation() ? 1 : 0); }
 };
 
 inline std::ostream& operator<<(std::ostream& out, Literal lit)

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -59,8 +59,7 @@ Solver::Clause_range Solver::learn(std::vector<Clause>&& clauses)
         }
         else // lhs.size() == rhs.size()
         {
-            auto [lhs_it, rhs_it] = std::mismatch(lhs.begin(), lhs.end(), rhs.begin());
-            return lhs_it->var().ord() < rhs_it->var().ord();
+            return lhs < rhs;
         }
     });
     clauses.erase(std::unique(clauses.begin(), clauses.end()), clauses.end());

--- a/src/Variable.h
+++ b/src/Variable.h
@@ -22,12 +22,45 @@ public:
      */
     inline Variable(int ord, Type type) : number(ord), var_type(type) {}
 
-    // comparable
+    /** Check whether this variable is equal to @p other
+     * 
+     * @param other other variable
+     * @return true if this variable is equal to @p other
+     */
     inline bool operator==(Variable const& other) const
     {
         return var_type == other.var_type && number == other.number;
     }
+
+    /** Check whether this variable is equal to @p other
+     * 
+     * @param other other variable
+     * @return true if this variable is not equal to @p other
+     */
     inline bool operator!=(Variable const& other) const { return !operator==(other); }
+
+    /** Three-way comparison of two variables
+     * 
+     * @param other other variable
+     * @return value < 0 if this variable is less than @p other
+     * @return value > 0 if this variable is greater than @p other
+     * @return value == 0 if this variable is equal to @p other
+     */
+    inline int operator<=>(Variable const& other) const
+    {
+        if (type() < other.type())
+        {
+            return -1;
+        }
+        else if (type() > other.type())
+        {
+            return 1;
+        }
+        else // type() == other.type()
+        {
+            return ord() - other.ord();
+        }
+    }
 
     // get 0-based ordinal number of this variable
     inline int ord() const { return number; }

--- a/src/Variable.h
+++ b/src/Variable.h
@@ -2,6 +2,7 @@
 #define YAGA_VARIABLE_H
 
 #include <ostream>
+#include <tuple>
 
 namespace yaga {
 
@@ -46,20 +47,9 @@ public:
      * @return value > 0 if this variable is greater than @p other
      * @return value == 0 if this variable is equal to @p other
      */
-    inline int operator<=>(Variable const& other) const
+    inline auto operator<=>(Variable const& other) const
     {
-        if (type() < other.type())
-        {
-            return -1;
-        }
-        else if (type() > other.type())
-        {
-            return 1;
-        }
-        else // type() == other.type()
-        {
-            return ord() - other.ord();
-        }
+        return std::pair{type(), ord()} <=> std::pair{other.type(), other.ord()};
     }
 
     // get 0-based ordinal number of this variable

--- a/tests/lra/Smtlib_parser_test.cpp
+++ b/tests/lra/Smtlib_parser_test.cpp
@@ -13,254 +13,6 @@
 #include "Smt2_parser.h"
 #include "Yaga.h"
 
-class Parser_test {
-private:
-    std::stringstream input_stream;
-    std::stringstream output_stream;
-    yaga::Solver_answer last_answer;
-    std::unordered_map<std::string, bool> bool_model;
-    std::unordered_map<std::string, yaga::Rational> lra_model;
-    yaga::parser::Smt2_parser parser;
-
-    /** Read parser answer from the output
-     */
-    inline void read_answer()
-    {
-        std::string line;
-        std::getline(output(), line);
-        if (line == "sat")
-        {
-            last_answer = yaga::Solver_answer::SAT;
-        }
-        else if (line == "unsat")
-        {
-            last_answer = yaga::Solver_answer::UNSAT;
-        }
-        else if (line == "error")
-        {
-            last_answer = yaga::Solver_answer::ERROR;
-        }
-        else 
-        {
-            last_answer = yaga::Solver_answer::UNKNOWN;
-        }
-    }
-
-    /** Parse an integer from an input stream as rational
-     * 
-     * @param input input stream with an integer
-     * @return parsed integer as a rational number
-     */
-    inline yaga::Rational parse_integer(std::istream& input)
-    {
-        yaga::Rational ret{0};
-        while (!input.fail() && !input.eof())
-        {
-            auto c = input.get();
-            if (std::isdigit(c))
-            {
-                ret = ret * 10 + (c - '0');
-            }
-            else
-            {
-                break;
-            }
-        }
-        return ret;
-    }
-
-    /** Skip whitespace characters in @p input
-     * 
-     * @param input input character stream
-     */
-    inline void skip_space(std::istream& input)
-    {
-        while (!input.fail() && !input.eof() && std::isspace(input.peek()))
-        {
-            input.get();
-        }
-    }
-
-    /** Skip @p cp from @p input
-     * 
-     * @param input input stream
-     * @param cp code point to skip
-     */
-    inline void skip(std::istream& input, int cp)
-    {
-        skip_space(input);
-        if (input.peek() == cp)
-        {
-            input.get();
-        }
-    }
-
-    /** Parse `<natural>` or `(- <natural>)`
-     * 
-     * @param input input character stream
-     * @return parsed integer
-     */
-    inline yaga::Rational parse_num(std::istream& input)
-    {
-        yaga::Rational ret{0};
-        skip_space(input);
-        if (input.peek() == '(')
-        {
-            skip(input, '(');
-            skip_space(input);
-            skip(input, '-');
-            skip_space(input);
-            ret = parse_integer(input);
-            ret.negate();
-            skip(input, ')');
-        }
-        else
-        {
-            ret = parse_integer(input);
-        }
-        return ret;
-    }
-
-    /** Parse a rational value expression:
-     * - `<natural>`
-     * - `(- <natural>)`
-     * - `(/ <natural> <natural>)`
-     * - `(/ (- <natural>) <natural>)`
-     * 
-     * @param input input character stream
-     * @return rational value parsed from @p input
-     */
-    inline yaga::Rational parse_rational(std::istream& input)
-    {
-        yaga::Rational ret{0};
-
-        skip_space(input);
-        if (input.peek() == '(')
-        {
-            skip(input, '(');
-            skip_space(input);
-
-            if (input.peek() == '-')
-            {
-                skip(input, '-');
-                skip_space(input);
-                ret = parse_integer(input);
-                ret.negate();
-            }
-            else if (input.peek() == '/')
-            {
-                skip(input, '/');
-                auto num = parse_num(input);
-
-                skip_space(input);
-                auto denom = parse_integer(input);
-                ret = num / denom;
-            }
-            else
-            {
-                throw std::logic_error{"Invalid rational expression."};
-            }
-
-            skip_space(input);
-            skip(input, ')');
-        }
-        else
-        {
-            ret = parse_integer(input);
-        }
-        return ret;
-    }
-
-    /** Read values of variables.
-     */
-    inline void read_model()
-    {
-        bool_model.clear();
-        lra_model.clear();
-        std::regex define{"\\(define-fun ([A-Za-z0-9]+) \\(\\) ([A-Za-z0-9]+) (.+)\\)"};
-
-        // skip (
-        char begin;
-        output() >> begin;
-        for (;;)
-        {
-            std::string line;
-            std::getline(output(), line);
-
-            std::smatch match;
-            if (std::regex_match(line, match, define))
-            {
-                auto name = match[1];
-                auto type = match[2];
-                std::stringstream value{match[3]};
-                if (type == "Bool")
-                {
-                    bool_model.insert({name, value.str() == "true"});
-                }
-                else if (type == "Real")
-                {
-                    lra_model.insert({name, parse_rational(value)});
-                }
-            }
-            else
-            {
-                break;
-            }
-        }
-    }
-public:
-    /** Stream with SMT-LIB input
-     * 
-     * @return reference to the input stream
-     */
-    inline std::stringstream& input() { return input_stream; }
-
-    /** Stream with parser output
-     * 
-     * @return stream with output 
-     */
-    inline std::stringstream& output() { return output_stream; }
-
-    /** Get solver answer of the last `run()` call.
-     * 
-     * @return answer of the last check.
-     */
-    inline yaga::Solver_answer answer() const { return last_answer; }
-
-    /** Run the parser with `input()`.
-     */
-    inline void run()
-    {
-        input() << "(check-sat)\n(get-model)\n";
-        parser.parse(input(), output());
-        output().seekg(0, std::ios::beg);
-        read_answer();
-        read_model();
-    }
-
-    /** Get value of a boolean variable
-     * 
-     * @param name name of a boolean variable
-     * @return value of the variable @p name
-     */
-    inline std::optional<bool> boolean(std::string const& name) const
-    {
-        auto it = bool_model.find(name);
-        return it != bool_model.end() ? std::optional{it->second} : std::nullopt;
-    }
-
-    /** Get value of a rational variable
-     * 
-     * @param name name of a rational variable
-     * @return value of the variable @p name
-     */
-    inline std::optional<yaga::Rational> real(std::string const& name) const
-    {
-        auto it = lra_model.find(name);
-        return it != lra_model.end() ? std::optional{it->second} : std::nullopt;
-    }
-};
-
 TEST_CASE("Parse boolean functions", "[test_parser]")
 {
     using namespace yaga;
@@ -268,7 +20,7 @@ TEST_CASE("Parse boolean functions", "[test_parser]")
     using namespace yaga::terms;
     using namespace yaga::test;
 
-    Parser_test test;
+    Yaga_test test;
     test.input() << "(declare-fun b1 () Bool)\n";
     test.input() << "(declare-fun b2 () Bool)\n";
     test.input() << "(declare-fun b3 () Bool)\n";
@@ -380,7 +132,7 @@ TEST_CASE("Parse boolean equality", "[test_parser]")
     using namespace yaga::terms;
     using namespace yaga::test;
 
-    Parser_test test;
+    Yaga_test test;
     test.input() << "(declare-fun b1 () Bool)\n";
     test.input() << "(declare-fun b2 () Bool)\n";
     test.input() << "(declare-fun b3 () Bool)\n";
@@ -468,7 +220,7 @@ TEST_CASE("Parse linear polynomial", "[test_parser]")
     using namespace yaga;
     using namespace yaga::test;
 
-    Parser_test test;
+    Yaga_test test;
     test.input() << "(declare-fun x () Real)\n";
     test.input() << "(declare-fun y () Real)\n";
     test.input() << "(declare-fun z () Real)\n";
@@ -591,7 +343,7 @@ TEST_CASE("Parse if-then-else with real output", "[test_parser]")
     using namespace yaga;
     using namespace yaga::test;
 
-    Parser_test test;
+    Yaga_test test;
     test.input() << "(declare-fun x () Real)\n";
     test.input() << "(declare-fun y () Real)\n";
     test.input() << "(declare-fun z () Real)\n";

--- a/tests/test.h
+++ b/tests/test.h
@@ -5,11 +5,19 @@
 #include <cassert>
 #include <tuple>
 #include <ranges>
+#include <regex>
+#include <string>
+#include <sstream>
+#include <unordered_map>
+#include <vector>
 
 #include "test_expr.h"
 #include "Literal.h"
 #include "Clause.h"
 #include "Linear_constraints.h"
+#include "Rational.h"
+#include "Solver_answer.h"
+#include "Smt2_parser.h"
 
 namespace yaga::test {
 
@@ -54,6 +62,256 @@ inline Clause clause(Linear_constraint<Value> cons, Linear_constraint<Tail>... t
 {
     return clause(cons.lit(), tail.lit()...);
 }
+
+/** Parse formula in LRA and run the solver.
+ */
+class Yaga_test {
+private:
+    std::stringstream input_stream;
+    std::stringstream output_stream;
+    yaga::Solver_answer last_answer;
+    std::unordered_map<std::string, bool> bool_model;
+    std::unordered_map<std::string, yaga::Rational> lra_model;
+    yaga::parser::Smt2_parser parser;
+
+    /** Read parser answer from the output
+     */
+    inline void read_answer()
+    {
+        std::string line;
+        std::getline(output(), line);
+        if (line == "sat")
+        {
+            last_answer = yaga::Solver_answer::SAT;
+        }
+        else if (line == "unsat")
+        {
+            last_answer = yaga::Solver_answer::UNSAT;
+        }
+        else if (line == "error")
+        {
+            last_answer = yaga::Solver_answer::ERROR;
+        }
+        else 
+        {
+            last_answer = yaga::Solver_answer::UNKNOWN;
+        }
+    }
+
+    /** Parse an integer from an input stream as rational
+     * 
+     * @param input input stream with an integer
+     * @return parsed integer as a rational number
+     */
+    inline yaga::Rational parse_integer(std::istream& input)
+    {
+        yaga::Rational ret{0};
+        while (!input.fail() && !input.eof())
+        {
+            auto c = input.get();
+            if (std::isdigit(c))
+            {
+                ret = ret * 10 + (c - '0');
+            }
+            else
+            {
+                break;
+            }
+        }
+        return ret;
+    }
+
+    /** Skip whitespace characters in @p input
+     * 
+     * @param input input character stream
+     */
+    inline void skip_space(std::istream& input)
+    {
+        while (!input.fail() && !input.eof() && std::isspace(input.peek()))
+        {
+            input.get();
+        }
+    }
+
+    /** Skip @p cp from @p input
+     * 
+     * @param input input stream
+     * @param cp code point to skip
+     */
+    inline void skip(std::istream& input, int cp)
+    {
+        skip_space(input);
+        if (input.peek() == cp)
+        {
+            input.get();
+        }
+    }
+
+    /** Parse `<natural>` or `(- <natural>)`
+     * 
+     * @param input input character stream
+     * @return parsed integer
+     */
+    inline yaga::Rational parse_num(std::istream& input)
+    {
+        yaga::Rational ret{0};
+        skip_space(input);
+        if (input.peek() == '(')
+        {
+            skip(input, '(');
+            skip_space(input);
+            skip(input, '-');
+            skip_space(input);
+            ret = parse_integer(input);
+            ret.negate();
+            skip(input, ')');
+        }
+        else
+        {
+            ret = parse_integer(input);
+        }
+        return ret;
+    }
+
+    /** Parse a rational value expression:
+     * - `<natural>`
+     * - `(- <natural>)`
+     * - `(/ <natural> <natural>)`
+     * - `(/ (- <natural>) <natural>)`
+     * 
+     * @param input input character stream
+     * @return rational value parsed from @p input
+     */
+    inline yaga::Rational parse_rational(std::istream& input)
+    {
+        yaga::Rational ret{0};
+
+        skip_space(input);
+        if (input.peek() == '(')
+        {
+            skip(input, '(');
+            skip_space(input);
+
+            if (input.peek() == '-')
+            {
+                skip(input, '-');
+                skip_space(input);
+                ret = parse_integer(input);
+                ret.negate();
+            }
+            else if (input.peek() == '/')
+            {
+                skip(input, '/');
+                auto num = parse_num(input);
+
+                skip_space(input);
+                auto denom = parse_integer(input);
+                ret = num / denom;
+            }
+            else
+            {
+                throw std::logic_error{"Invalid rational expression."};
+            }
+
+            skip_space(input);
+            skip(input, ')');
+        }
+        else
+        {
+            ret = parse_integer(input);
+        }
+        return ret;
+    }
+
+    /** Read values of variables.
+     */
+    inline void read_model()
+    {
+        bool_model.clear();
+        lra_model.clear();
+        std::regex define{"\\(define-fun ([A-Za-z0-9]+) \\(\\) ([A-Za-z0-9]+) (.+)\\)"};
+
+        // skip (
+        char begin;
+        output() >> begin;
+        for (;;)
+        {
+            std::string line;
+            std::getline(output(), line);
+
+            std::smatch match;
+            if (std::regex_match(line, match, define))
+            {
+                auto name = match[1];
+                auto type = match[2];
+                std::stringstream value{match[3]};
+                if (type == "Bool")
+                {
+                    bool_model.insert({name, value.str() == "true"});
+                }
+                else if (type == "Real")
+                {
+                    lra_model.insert({name, parse_rational(value)});
+                }
+            }
+            else
+            {
+                break;
+            }
+        }
+    }
+public:
+    /** Stream with SMT-LIB input
+     * 
+     * @return reference to the input stream
+     */
+    inline std::stringstream& input() { return input_stream; }
+
+    /** Stream with parser output
+     * 
+     * @return stream with output 
+     */
+    inline std::stringstream& output() { return output_stream; }
+
+    /** Get solver answer of the last `run()` call.
+     * 
+     * @return answer of the last check.
+     */
+    inline yaga::Solver_answer answer() const { return last_answer; }
+
+    /** Run the parser with `input()`.
+     */
+    inline void run()
+    {
+        input() << "(check-sat)\n(get-model)\n";
+        parser.parse(input(), output());
+        output().seekg(0, std::ios::beg);
+        read_answer();
+        read_model();
+    }
+
+    /** Get value of a boolean variable
+     * 
+     * @param name name of a boolean variable
+     * @return value of the variable @p name
+     */
+    inline std::optional<bool> boolean(std::string const& name) const
+    {
+        auto it = bool_model.find(name);
+        return it != bool_model.end() ? std::optional{it->second} : std::nullopt;
+    }
+
+    /** Get value of a rational variable
+     * 
+     * @param name name of a rational variable
+     * @return value of the variable @p name
+     */
+    inline std::optional<yaga::Rational> real(std::string const& name) const
+    {
+        auto it = lra_model.find(name);
+        return it != lra_model.end() ? std::optional{it->second} : std::nullopt;
+    }
+};
 
 }
 


### PR DESCRIPTION
Previously, the `Solver::learn()` method could read from an end iterator if there were two equal learned clauses.

The added test shows why we should deduplicate learned clauses and linear constraints. The solver decides `y = 0` and `b = true`, which leads to two bound conflicts:
- `not(x + y < 0)`, `not(x > 0)`, `y < 0`
- `not(z + y < 0)`, `not(z > 0)`, `y < 0` (duplicate linear constraint `y < 0`)

Conflict analysis of both clauses produces the same clause: `not b or y < 0`.