### PR TITLE
SMT solver: fix error reporting

### DIFF
--- a/src/smt_solver.cpp
+++ b/src/smt_solver.cpp
@@ -76,7 +76,18 @@ int main(int argc, char** argv)
         return -1;
     }
 
-    parser::Smt2_parser parser;
-    parser.set_options(options);
-    parser.parse_file(input_path);
+    try
+    {
+        parser::Smt2_parser parser;
+        parser.set_options(options);
+        parser.parse_file(input_path);
+    }
+    catch (std::ifstream::failure& e)
+    {
+        std::cout << "Error: failed to open the input file '" << input_path << "'\n";
+    }
+    catch (std::exception& e) 
+    {
+        std::cout << "Error: " << e.what() << "\n";
+    }
 }

--- a/src/smt_solver.cpp
+++ b/src/smt_solver.cpp
@@ -84,10 +84,10 @@ int main(int argc, char** argv)
     }
     catch (std::ifstream::failure& e)
     {
-        std::cout << "Error: failed to open the input file '" << input_path << "'\n";
+        std::cerr << "Error: failed to open the input file '" << input_path << "'\n";
     }
     catch (std::exception& e) 
     {
-        std::cout << "Error: " << e.what() << "\n";
+        std::cerr << "Error: " << e.what() << "\n";
     }
 }


### PR DESCRIPTION
The SAT and SMT solver should catch parser errors and produce error messages instead of crashing.