### PR TITLE
Support for QF_LIA in LRA plugin, adhoc model printing solution

### DIFF
--- a/src/Restart.h
+++ b/src/Restart.h
@@ -119,7 +119,7 @@ public:
         auto it = levels.begin();
         for (auto lit : learned)
         {
-            *it++ = trail.decision_level(lit.var()).value();
+            *it++ = trail.decision_level(lit.var()).value_or(0);
         }
         std::sort(levels.begin(), levels.end());
         add_glucose(std::distance(levels.begin(), std::unique(levels.begin(), levels.end())));

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -66,16 +66,6 @@ Solver::Clause_range Solver::learn(std::vector<Clause>&& clauses)
     });
     clauses.erase(std::unique(clauses.begin(), clauses.end()), clauses.end());
 
-    // prefer UIP clauses (propagations) over semantic split clauses (decisions)
-    if (std::any_of(clauses.begin(), clauses.end(), [&](auto const& learned) {
-        return !is_semantic_split(learned);
-    }))
-    {
-        clauses.erase(std::remove_if(clauses.begin(), clauses.end(), [&](auto const& learned) {
-            return is_semantic_split(learned);
-        }), clauses.end());
-    }
-
     for (auto const& clause : clauses)
     {
         ++total_learned_clauses;

--- a/src/Yaga.cpp
+++ b/src/Yaga.cpp
@@ -55,6 +55,52 @@ void Qf_uflra::setup(Yaga* yaga, Options const& options) const
     yaga->solver().set_variable_order<Generalized_vsids>(lra);
 }
 
+void Qf_lia::setup(Yaga* yaga, Options const& options) const
+{
+    yaga->solver().trail().set_model<bool>(Variable::boolean, 0);
+    yaga->solver().trail().set_model<Rational>(Variable::rational, 0);
+    // create plugins
+    auto& theories = yaga->solver().set_theory<Theory_combination>();
+    auto& bcp = theories.add_theory<Bool_theory>();
+    bcp.set_phase(options.phase);
+
+    Linear_arithmetic::Options lra_options;
+    lra_options.prop_rational = options.prop_rational;
+    lra_options.prop_bounds = options.deduce_bounds;
+    lra_options.prop_integer = true;
+    auto& lra = theories.add_theory<Linear_arithmetic>();
+    lra.set_options(lra_options);
+
+    // add heuristics
+    yaga->solver().set_restart_policy<Glucose_restart>();
+    yaga->solver().set_variable_order<Generalized_vsids>(lra);
+}
+
+    void Qf_uflia::setup(Yaga* yaga, Options const& options) const
+{
+    yaga->solver().trail().set_model<bool>(Variable::boolean, 0);
+    yaga->solver().trail().set_model<Rational>(Variable::rational, 0);
+    // create plugins
+    auto& theories = yaga->solver().set_theory<Theory_combination>();
+    auto& bcp = theories.add_theory<Bool_theory>();
+    bcp.set_phase(options.phase);
+
+    Linear_arithmetic::Options lra_options;
+    lra_options.prop_rational = options.prop_rational;
+    lra_options.prop_bounds = options.deduce_bounds;
+    lra_options.prop_integer = true;
+    auto& lra = theories.add_theory<Linear_arithmetic>();
+    lra.set_options(lra_options);
+
+    theories.add_theory<Uninterpreted_functions>(yaga->solver().tm(), yaga->real_vars(), yaga->bool_vars());
+
+    // add heuristics
+    yaga->solver().set_restart_policy<Glucose_restart>();
+    yaga->solver().set_variable_order<Generalized_vsids>(lra);
+}
+
+
+
 Yaga::Yaga(terms::Term_manager const& tm,
            std::ranges::ref_view<std::unordered_map<yaga::terms::term_t, int> > r_m,
            std::ranges::ref_view<std::unordered_map<yaga::terms::term_t, Literal> > b_m)

--- a/src/Yaga.cpp
+++ b/src/Yaga.cpp
@@ -66,7 +66,8 @@ void Qf_lia::setup(Yaga* yaga, Options const& options) const
 
     Linear_arithmetic::Options lra_options;
     lra_options.prop_rational = options.prop_rational;
-    lra_options.prop_bounds = options.deduce_bounds;
+    lra_options.prop_bounds = true;
+    lra_options.prop_unassigned = true;
     lra_options.prop_integer = true;
     auto& lra = theories.add_theory<Linear_arithmetic>();
     lra.set_options(lra_options);
@@ -87,7 +88,8 @@ void Qf_lia::setup(Yaga* yaga, Options const& options) const
 
     Linear_arithmetic::Options lra_options;
     lra_options.prop_rational = options.prop_rational;
-    lra_options.prop_bounds = options.deduce_bounds;
+    lra_options.prop_bounds = true;
+    lra_options.prop_unassigned = true;
     lra_options.prop_integer = true;
     auto& lra = theories.add_theory<Linear_arithmetic>();
     lra.set_options(lra_options);

--- a/src/Yaga.h
+++ b/src/Yaga.h
@@ -82,6 +82,35 @@ public:
     void setup(Yaga* solver, Options const& options) const override;
 };
 
+    /** Initializer for quantifier-free linear integer arithmetic.
+ */
+    class Qf_lia final : public Initializer {
+    public:
+        virtual ~Qf_lia() = default;
+
+        /** Initialize @p solver with plugins for boolean variables and integer variables.
+         *
+         * @param solver solver to initialize
+         * @param options command line options
+         */
+        void setup(Yaga* solver, Options const& options) const override;
+    };
+
+    /** Initializer for quantifier-free linear integer arithmetic with uninterpreted functions.
+     */
+    class Qf_uflia final : public Initializer {
+    public:
+        virtual ~Qf_uflia() = default;
+
+        /** Initialize @p solver with plugins for boolean variables, integer variables and uninterpreted functions.
+         *
+         * @param solver solver to initialize
+         * @param options command line options
+         */
+        void setup(Yaga* solver, Options const& options) const override;
+    };
+
+
 /** Predefined logic initializers for the Yaga facade.
  */
 struct logic {
@@ -96,6 +125,14 @@ struct logic {
     /** Quantifier-free linear real arithmetic
      */
     inline static Qf_lra const qf_lra{};
+
+    /** Quantifier-free linear integer arithmetic with uninterpreted functions
+     */
+    inline static Qf_uflia const qf_uflia{};
+
+    /** Quantifier-free linear integer arithmetic
+     */
+    inline static Qf_lia const qf_lia{};
 };
 
 /** A facade for the SMT solver.

--- a/src/lra/Bounds.cpp
+++ b/src/lra/Bounds.cpp
@@ -74,6 +74,7 @@ void Bounds::deduce_from_equality(Models const& models, Constraint const& cons)
     }
 
     float max_deps = std::max<float>(threshold * cons.vars().size(), 0);
+    max_deps = std::min<float>(max_deps, 200.f);
     int i = 0;
     for (auto& prop : props)
     {
@@ -152,6 +153,7 @@ void Bounds::deduce_from_inequality(Models const& models, Constraint const& cons
     }
 
     float max_deps = std::max<float>(threshold * cons.vars().size(), 0);
+    max_deps = std::min<float>(max_deps, 200.f);
     if (count_distinct_bounds(deps) <= max_deps && num_unbounded == 1)
     {
         bound /= unbounded_coef;

--- a/src/lra/Bounds.h
+++ b/src/lra/Bounds.h
@@ -100,7 +100,7 @@ private:
     std::vector<int> updated_read;
     std::vector<int> updated_write;
     // maximum number of dependencies of a bound (as a percentage of the number of variables)
-    float threshold = 1.0;
+    float threshold = 20.0;
 
     // properties deduced from a linear constraint
     struct Deduced_properties {

--- a/src/lra/Linear_arithmetic.cpp
+++ b/src/lra/Linear_arithmetic.cpp
@@ -258,12 +258,12 @@ bool Linear_arithmetic::is_fully_assigned(Model<Rational> const& model,
 
 std::optional<Clause> Linear_arithmetic::check_bounds(Trail& trail, int var_ord)
 {
-    if (auto conflict = Bound_conflict_analysis{this}.analyze(trail, bounds, var_ord))
+    if (auto conflict = Bound_conflict_analysis{this, options.prop_integer}.analyze(trail, bounds, var_ord))
     {
         return conflict;
     }
 
-    if (auto conflict = Inequality_conflict_analysis{this}.analyze(trail, bounds, var_ord))
+    if (auto conflict = Inequality_conflict_analysis{this, options.prop_integer}.analyze(trail, bounds, var_ord))
     {
         return conflict;
     }
@@ -523,6 +523,8 @@ void Linear_arithmetic::decide(Database&, Trail& trail, Variable var)
         }
         else // there is no suitable integer value
         {
+            // LRA has to be chosen, otherwise a conflict should be detected
+            assert(!options.prop_integer);
             assert(bnds.lower_bound(models) != nullptr);
             assert(bnds.upper_bound(models) != nullptr);
 

--- a/src/lra/Linear_arithmetic.cpp
+++ b/src/lra/Linear_arithmetic.cpp
@@ -1,7 +1,5 @@
 #include "Linear_arithmetic.h"
 
-#include "Conflict_analysis.h"
-
 #include <array>
 #include <unordered_set>
 
@@ -10,12 +8,6 @@ namespace yaga {
 namespace {
 
 using Models = Linear_arithmetic::Models;
-
-Clause compute_uip(Trail const& trail, Clause&& conflict)
-{
-    Conflict_analysis analysis;
-    return analysis.analyze(trail, std::move(conflict)).first;
-}
 
 void add_assignment_literal(Linear_arithmetic* lra, Trail& trail, Models& models, Clause& out,
                             int var_ord)
@@ -114,7 +106,7 @@ std::vector<Clause> Linear_arithmetic::propagate(Database&, Trail& trail)
                     {
                         add_assignment_literal(this, trail, models, conflict, lra_var_ord);
                     }
-                    pending_conflict = compute_uip(trail, std::move(conflict));
+                    pending_conflict = std::move(conflict);
                     break;
                 }
             }
@@ -144,12 +136,17 @@ std::vector<Clause> Linear_arithmetic::propagate(Database&, Trail& trail)
 
     if (options.prop_bounds)
     {
-        propagate_bounds(trail, models);
+        std::vector<int> changed_bounds;
+        propagate_bounds(models, variables, scan_vars, changed_bounds);
+        to_check.insert(to_check.end(), changed_bounds.begin(), changed_bounds.end());
+        scan_vars.insert(scan_vars.end(), changed_bounds.begin(), changed_bounds.end());
     }
-
-    auto const& changed = bounds.changed();
-    to_check.insert(to_check.end(), changed.begin(), changed.end());
-    scan_vars.insert(scan_vars.end(), changed.begin(), changed.end());
+    else
+    {
+        auto const& changed = bounds.changed();
+        to_check.insert(to_check.end(), changed.begin(), changed.end());
+        scan_vars.insert(scan_vars.end(), changed.begin(), changed.end());
+    }
 
     if (options.prop_unassigned && !scan_vars.empty())
     {
@@ -291,7 +288,7 @@ void Linear_arithmetic::replace_watch(Trail& trail, Models& models, int lra_var_
                         {
                             add_assignment_literal(this, trail, models, conflict, other_var_ord);
                         }
-                        pending_conflict = compute_uip(trail, std::move(conflict));
+                        pending_conflict = std::move(conflict);
                         return;
                     }
                 }
@@ -343,8 +340,9 @@ bool Linear_arithmetic::is_unit(Model<Rational> const& model, Constraint const& 
 bool Linear_arithmetic::is_fully_assigned(Model<Rational> const& model,
                                           Constraint const& cons) const
 {
-    return cons.empty() || std::all_of(cons.vars().begin(), cons.vars().end(), [&](int v){return model.is_defined(v);});
-    //return cons.empty() || model.is_defined(cons.vars().front());
+    return cons.empty() ||
+           std::all_of(cons.vars().begin(), cons.vars().end(),
+                       [&](int v) { return model.is_defined(v); });
 }
 
 std::optional<Clause> Linear_arithmetic::check_bounds(Trail& trail, int var_ord)
@@ -366,25 +364,120 @@ void Linear_arithmetic::unit(Models const& models, Constraint const& cons)
     bounds.update(models, cons); 
 }
 
-void Linear_arithmetic::propagate_bounds(Trail const& trail, Models const& models)
+void Linear_arithmetic::propagate_bounds(Models const& models,
+                                         std::vector<Variable> const& assigned_vars,
+                                         std::vector<int> const& assigned_rationals,
+                                         std::vector<int>& out_changed)
 {
-    for (auto& [var, _] : trail.assigned(trail.decision_level()))
-    {
-        if (var.type() == Variable::boolean)
+    out_changed.clear();
+
+    std::vector<int> queue;
+    queue.reserve(128);
+
+    std::vector<char> in_queue(models.boolean().num_vars(), false);
+    auto enqueue = [&](int bool_ord) {
+        if (bool_ord < 0 || bool_ord >= static_cast<int>(in_queue.size()))
         {
-            auto cons = constraint(var.ord());
-            if (cons.empty())
-            {
-                continue; // var does not represent a linear constraint
-            }
-            if (!models.boolean().value(var.ord()))
-            {
-                cons.negate();
-            }
-            assert(models.boolean().value(cons.lit().var().ord()) == !cons.lit().is_negation());
-            bounds.deduce(models, cons);
+            return;
+        }
+        if (!in_queue[bool_ord])
+        {
+            in_queue[bool_ord] = true;
+            queue.push_back(bool_ord);
+        }
+    };
+
+    // Seed with constraints whose boolean variables were just assigned.
+    for (auto var : assigned_vars)
+    {
+        if (var.type() == Variable::boolean && !constraints[var.ord()].empty())
+        {
+            enqueue(var.ord());
         }
     }
+
+    // Seed with constraints that mention newly assigned rational variables.
+    for (auto var_ord : assigned_rationals)
+    {
+        for (auto cons : occur[var_ord])
+        {
+            auto bool_ord = cons.lit().var().ord();
+            if (models.boolean().is_defined(bool_ord))
+            {
+                enqueue(bool_ord);
+            }
+        }
+    }
+
+    // Also seed with any bounds/inequalities derived before we got here (e.g., from unit
+    // constraints while replacing watches).
+    auto initial_changed = bounds.changed();
+    out_changed.insert(out_changed.end(), initial_changed.begin(), initial_changed.end());
+    for (auto var_ord : initial_changed)
+    {
+        for (auto cons : occur[var_ord])
+        {
+            auto bool_ord = cons.lit().var().ord();
+            if (models.boolean().is_defined(bool_ord))
+            {
+                enqueue(bool_ord);
+            }
+        }
+    }
+
+    // Propagate FM deductions to a fixpoint (with a coarse budget cap).
+    std::size_t index = 0;
+    int budget = 20000;
+    while (index < queue.size() && budget > 0)
+    {
+        auto bool_ord = queue[index++];
+        in_queue[bool_ord] = false;
+        --budget;
+
+        if (!models.boolean().is_defined(bool_ord))
+        {
+            continue;
+        }
+
+        auto cons = constraint(bool_ord);
+        if (cons.empty())
+        {
+            continue;
+        }
+
+        if (!models.boolean().value(bool_ord))
+        {
+            cons.negate();
+        }
+        assert(models.boolean().value(cons.lit().var().ord()) == !cons.lit().is_negation());
+        bounds.deduce(models, cons);
+
+        if (index == queue.size())
+        {
+            auto const& changed = bounds.changed();
+            if (changed.empty())
+            {
+                continue;
+            }
+
+            out_changed.insert(out_changed.end(), changed.begin(), changed.end());
+            for (auto var_ord : changed)
+            {
+                for (auto occ : occur[var_ord])
+                {
+                    auto occ_bool_ord = occ.lit().var().ord();
+                    if (models.boolean().is_defined(occ_bool_ord))
+                    {
+                        enqueue(occ_bool_ord);
+                    }
+                }
+            }
+        }
+    }
+
+    // Drain any remaining bound updates.
+    auto const& trailing_changed = bounds.changed();
+    out_changed.insert(out_changed.end(), trailing_changed.begin(), trailing_changed.end());
 }
 
 void Linear_arithmetic::propagate_unassigned(Trail& trail, Models& models,

--- a/src/lra/Linear_arithmetic.cpp
+++ b/src/lra/Linear_arithmetic.cpp
@@ -1,6 +1,45 @@
 #include "Linear_arithmetic.h"
 
+#include "Conflict_analysis.h"
+
+#include <array>
+#include <unordered_set>
+
 namespace yaga {
+
+namespace {
+
+using Models = Linear_arithmetic::Models;
+
+Clause compute_uip(Trail const& trail, Clause&& conflict)
+{
+    Conflict_analysis analysis;
+    return analysis.analyze(trail, std::move(conflict)).first;
+}
+
+void add_assignment_literal(Linear_arithmetic* lra, Trail& trail, Models& models, Clause& out,
+                            int var_ord)
+{
+    if (!models.owned().is_defined(var_ord))
+    {
+        return;
+    }
+
+    std::array<int, 1> vars{var_ord};
+    std::array<Rational, 1> coef{Rational{1}};
+    auto eq = lra->constraint(trail, vars, coef, Order_predicate::eq, models.owned().value(var_ord));
+
+    if (!models.boolean().is_defined(eq.lit().var().ord()))
+    {
+        lra->propagate(trail, models, eq);
+    }
+
+    assert(eval(models.owned(), eq) == true);
+    assert(eval(models.boolean(), eq.lit()) == true);
+    out.push_back(~eq.lit()); // add inequality: var != current_value
+}
+
+} // namespace
 
 void Linear_arithmetic::on_variable_resize(Variable::Type type, int num_vars)
 {
@@ -36,16 +75,22 @@ bool Linear_arithmetic::is_effectively_decided(Models const& models, int lra_var
 
 std::vector<Clause> Linear_arithmetic::propagate(Database&, Trail& trail)
 {
+    pending_conflict.reset();
     auto models = relevant_models(trail);
 
     // find relevant variables which have been assigned at current decision level
     std::vector<Variable> variables;
+    std::vector<int> scan_vars;
     for (auto [var, _] : assigned(trail))
     {
         if (var.type() == Variable::rational ||
             (var.type() == Variable::boolean && !constraints[var.ord()].empty()))
         {
             variables.push_back(var);
+            if (var.type() == Variable::rational)
+            {
+                scan_vars.push_back(var.ord());
+            }
         }
     }
 
@@ -58,7 +103,20 @@ std::vector<Clause> Linear_arithmetic::propagate(Database&, Trail& trail)
 
             if (is_fully_assigned(models.owned(), cons))
             {
-                assert(eval(models.owned(), cons) == eval(models.boolean(), cons.lit()));
+                auto bool_val = eval(models.boolean(), cons.lit());
+                auto theory_val = eval(models.owned(), cons);
+                if (bool_val.has_value() && theory_val.has_value() && bool_val != theory_val)
+                {
+                    Clause conflict;
+                    conflict.reserve(static_cast<std::size_t>(cons.size()) + 1);
+                    conflict.push_back(*theory_val ? cons.lit() : ~cons.lit());
+                    for (auto lra_var_ord : cons.vars())
+                    {
+                        add_assignment_literal(this, trail, models, conflict, lra_var_ord);
+                    }
+                    pending_conflict = compute_uip(trail, std::move(conflict));
+                    break;
+                }
             }
             else if (is_unit(models.owned(), cons))
             {
@@ -68,6 +126,10 @@ std::vector<Clause> Linear_arithmetic::propagate(Database&, Trail& trail)
         else if (var.type() == Variable::rational)
         {
             replace_watch(trail, models, var.ord());
+            if (pending_conflict)
+            {
+                break;
+            }
         }
         else
         {
@@ -75,14 +137,25 @@ std::vector<Clause> Linear_arithmetic::propagate(Database&, Trail& trail)
         }
     }
 
+    if (pending_conflict)
+    {
+        return {std::move(*pending_conflict)};
+    }
+
     if (options.prop_bounds)
     {
         propagate_bounds(trail, models);
     }
 
-    if (options.prop_unassigned)
+    auto const& changed = bounds.changed();
+    to_check.insert(to_check.end(), changed.begin(), changed.end());
+    scan_vars.insert(scan_vars.end(), changed.begin(), changed.end());
+
+    if (options.prop_unassigned && !scan_vars.empty())
     {
-        propagate_unassigned(trail, models);
+        std::sort(scan_vars.begin(), scan_vars.end());
+        scan_vars.erase(std::unique(scan_vars.begin(), scan_vars.end()), scan_vars.end());
+        propagate_unassigned(trail, models, scan_vars);
     }
     return finish(trail);
 }
@@ -187,6 +260,11 @@ void Linear_arithmetic::replace_watch(Trail& trail, Models& models, int lra_var_
     auto& watchlist = watched[lra_var_ord];
     for (std::size_t i = 0; i < watchlist.size();)
     {
+        if (pending_conflict)
+        {
+            return;
+        }
+
         auto& watch = watchlist[i];
         auto& cons = watch.constraint;
 
@@ -202,7 +280,20 @@ void Linear_arithmetic::replace_watch(Trail& trail, Models& models, int lra_var_
             {
                 if (is_fully_assigned(models.owned(), cons))
                 {
-                    assert(eval(models.owned(), cons) == eval(models.boolean(), cons.lit()));
+                    auto bool_val = eval(models.boolean(), cons.lit());
+                    auto theory_val = eval(models.owned(), cons);
+                    if (bool_val.has_value() && theory_val.has_value() && bool_val != theory_val)
+                    {
+                        Clause conflict;
+                        conflict.reserve(static_cast<std::size_t>(cons.size()) + 1);
+                        conflict.push_back(*theory_val ? cons.lit() : ~cons.lit());
+                        for (auto other_var_ord : cons.vars())
+                        {
+                            add_assignment_literal(this, trail, models, conflict, other_var_ord);
+                        }
+                        pending_conflict = compute_uip(trail, std::move(conflict));
+                        return;
+                    }
                 }
                 else // cons is unit
                 {
@@ -296,29 +387,36 @@ void Linear_arithmetic::propagate_bounds(Trail const& trail, Models const& model
     }
 }
 
-void Linear_arithmetic::propagate_unassigned(Trail& trail, Models& models)
+void Linear_arithmetic::propagate_unassigned(Trail& trail, Models& models,
+                                             std::vector<int> const& vars_to_check)
 {
-    if (trail.decision_level() == 0)
+    if (vars_to_check.empty())
     {
         return;
     }
 
-    auto decided_var = trail.assigned(trail.decision_level()).front().var;
-    if (decided_var.type() != Variable::rational)
+    std::unordered_set<int> seen;
+    for (auto var_ord : vars_to_check)
     {
-        return;
-    }
-
-    for (auto cons : occur[decided_var.ord()])
-    {
-        if (!models.boolean().is_defined(cons.lit().var().ord()))
+        for (auto cons : occur[var_ord])
         {
+            auto bool_ord = cons.lit().var().ord();
+            if (models.boolean().is_defined(bool_ord))
+            {
+                continue;
+            }
+            if (!seen.insert(bool_ord).second)
+            {
+                continue;
+            }
+
             for (auto c : {cons, ~cons})
             {
                 if (bounds.is_implied(models, c))
                 {
                     trail.propagate(c.lit().var(), nullptr, trail.decision_level());
-                    models.boolean().set_value(c.lit().var().ord(), !c.lit().is_negation());
+                    models.boolean().set_value(bool_ord, !c.lit().is_negation());
+                    break;
                 }
             }
         }
@@ -327,10 +425,6 @@ void Linear_arithmetic::propagate_unassigned(Trail& trail, Models& models)
 
 std::vector<Clause> Linear_arithmetic::finish(Trail& trail)
 {
-    // find all rational variables whose bound has changed
-    auto const& changed = bounds.changed();
-    to_check.insert(to_check.end(), changed.begin(), changed.end());
-
     // check for conflict
     auto models = relevant_models(trail);
     std::unordered_set<int> checked;

--- a/src/lra/Linear_arithmetic.h
+++ b/src/lra/Linear_arithmetic.h
@@ -51,6 +51,11 @@ public:
          * A rational variable is effectively decided if it can only be assigned one value.
          */
         bool prop_rational = false;
+
+        /**
+         * If true, the plugin will work with integer numbers instead of rationals.
+         */
+        bool prop_integer = false;
     };
 
     virtual ~Linear_arithmetic() = default;

--- a/src/lra/Linear_arithmetic.h
+++ b/src/lra/Linear_arithmetic.h
@@ -217,6 +217,8 @@ private:
     Model<Rational> cached_values;
     // list of rational variables whose bound has changed at this level
     std::vector<int> to_check;
+    // conflict detected during propagation (e.g., a fully assigned constraint mismatch)
+    std::optional<Clause> pending_conflict;
     // map real variable -> list of constraints in which it occurs
     std::vector<std::vector<Constraint>> occur;
     // parameters of optional features
@@ -288,7 +290,7 @@ private:
      * @param trail current solver trail
      * @param models partial assignment of variables
      */
-    void propagate_unassigned(Trail& trail, Models& models);
+    void propagate_unassigned(Trail& trail, Models& models, std::vector<int> const& vars_to_check);
 
     /** Finish propagation by checking if there are any conflicts.
      *

--- a/src/lra/Linear_arithmetic.h
+++ b/src/lra/Linear_arithmetic.h
@@ -280,10 +280,14 @@ private:
 
     /** Deduce new bounds using bounds added at this decision level
      *
-     * @param trail current solver trail
      * @param models partial assignment of variables
+     * @param assigned_vars new trail assignments since last propagate() call
+     * @param assigned_rationals newly assigned rational variables
+     * @param out_changed all variables whose bounds changed
      */
-    void propagate_bounds(Trail const& trail, Models const& models);
+    void propagate_bounds(Models const& models, std::vector<Variable> const& assigned_vars,
+                          std::vector<int> const& assigned_rationals,
+                          std::vector<int>& out_changed);
 
     /** Propagate true constraints to the trail
      *

--- a/src/lra/Lra_conflict_analysis.cpp
+++ b/src/lra/Lra_conflict_analysis.cpp
@@ -178,9 +178,10 @@ std::optional<Clause> Bound_conflict_analysis::analyze(Trail& trail, Bounds& bou
     }
     else
     {
-        if ((lb->value() + 1 < ub->value()) ||
-            (lb->value() + 1 == ub->value() && (
-                !lb->value().isInteger() ||
+        if ((lb->value() == ub->value() && !is_strict) ||
+            (lb->value() + 1 < ub->value()) ||
+            (lb->value() + 1 == ub->value() &&
+                (!lb->value().isInteger() ||
                 !is_strict)))
         {
             return {};

--- a/src/lra/Lra_conflict_analysis.cpp
+++ b/src/lra/Lra_conflict_analysis.cpp
@@ -230,10 +230,8 @@ std::optional<Clause> Inequality_conflict_analysis::analyze(Trail& trail, Bounds
         }
     } else {
         // check if there is still an integer between the bounds
-        if ((lb->value() + 1 < ub->value()) ||
-            (lb->value() + 1 == ub->value() &&
-                (!lb->value().isInteger() ||
-                (lb->reason().is_strict() || !ub->reason().is_strict()))))
+        if (lb->value() != ub->value() || lb->reason().is_strict() || ub->reason().is_strict() ||
+            !lb->value().isInteger())
         {
             return {};
         }

--- a/src/lra/Lra_conflict_analysis.cpp
+++ b/src/lra/Lra_conflict_analysis.cpp
@@ -73,6 +73,18 @@ Clause compute_uip(Trail const& trail, Clause&& conflict)
 
 } // namespace
 
+Rational Fm_elimination::integer_step() const
+{
+    Rational denom_lcm{1};
+    for (auto const& [_, coef] : poly.variables)
+    {
+        denom_lcm = lcm(denom_lcm, coef.denominator());
+    }
+    denom_lcm = lcm(denom_lcm, poly.constant.denominator());
+    assert(denom_lcm.isInteger());
+    return Rational{1} / denom_lcm;
+}
+
 void Fm_elimination::init(Constraint const& cons)
 {
     assert(cons.pred() != Order_predicate::eq || !cons.lit().is_negation()); // cons is not !=
@@ -111,6 +123,15 @@ void Fm_elimination::init(Constraint const& cons, Order_predicate p, Rational mu
         poly.variables.emplace_back(*var_it, *coef_it * mult);
     }
     poly.constant = -cons.rhs() * mult;
+
+    if (lia && pred == Order_predicate::lt)
+    {
+        // Strengthening for integer variables:
+        // For `poly < 0`, where poly evaluates to values in `k * step`, we can replace it by
+        // `poly + step <= 0`, which is equivalent over integers.
+        pred = Order_predicate::leq;
+        poly.constant += integer_step();
+    }
 }
 
 void Fm_elimination::init(Fm_elimination&& other)
@@ -210,7 +231,7 @@ Fm_elimination Lra_conflict_analysis::eliminate(Models const& models, Bounds& bo
     clause.push_back(~bound.reason().lit());
 
     // eliminate all unassigned variables in the linear constraint except for `bound.var()`
-    Fm_elimination fm{lra, bound.reason()};
+    Fm_elimination fm{lra, bound.reason(), lia};
     for (auto const& other : bound.bounds())
     {
         if (!models.owned().is_defined(other.var()))
@@ -275,8 +296,10 @@ std::optional<Clause> Bound_conflict_analysis::analyze(Trail& trail, Bounds& bou
             return {}; // there is an integer value between the bounds
         }
 
-        // Explain the conflict by collecting constraint assumptions and equalities of all
-        // assigned variables that were used to derive the conflicting bounds.
+        // Explain the conflict by (1) trying to derive a value-independent contradiction using
+        // FM elimination with integer strengthening and, if that fails, (2) falling back to
+        // adding assignment equalities for all assigned variables participating in the
+        // conflicting derivation.
         Lra_conflict_analysis analysis{lra, lia};
         auto fm_lb = analysis.eliminate(models, bounds, *lb);
         auto fm_ub = analysis.eliminate(models, bounds, *ub);
@@ -288,9 +311,34 @@ std::optional<Clause> Bound_conflict_analysis::analyze(Trail& trail, Bounds& bou
         std::sort(assigned_vars.begin(), assigned_vars.end());
         assigned_vars.erase(std::unique(assigned_vars.begin(), assigned_vars.end()), assigned_vars.end());
 
-        for (auto assigned_var : assigned_vars)
+        // Try to derive a contradiction independent of the current assignments.
+        auto fm = std::move(fm_lb);
+        fm.resolve(fm_ub, var_ord);
+        auto const is_contradiction = [&]() -> bool {
+            auto const& poly = fm.derived();
+            if (!poly.variables.empty())
+            {
+                return false;
+            }
+            switch (fm.predicate())
+            {
+            case Order_predicate::eq:
+                return poly.constant != 0;
+            case Order_predicate::lt:
+                return poly.constant >= 0;
+            case Order_predicate::leq:
+                return poly.constant > 0;
+            }
+            assert(false);
+            return false;
+        }();
+
+        if (!is_contradiction)
         {
-            add_assignment_literal(lra, trail, models, analysis.conflict(), assigned_var);
+            for (auto assigned_var : assigned_vars)
+            {
+                add_assignment_literal(lra, trail, models, analysis.conflict(), assigned_var);
+            }
         }
 
         auto clause = analysis.finish();
@@ -357,36 +405,47 @@ std::optional<Clause> Inequality_conflict_analysis::analyze(Trail& trail, Bounds
         {
             return {}; // bound conflict (handled by Bound_conflict_analysis)
         }
-        if (lb_int != ub_int)
-        {
-            return {}; // there is an integer value different from the disallowed one
-        }
-
-        auto const& value = lb_int; // the only integer value allowed by the bounds
-        auto neq = bounds[var_ord].inequality(models, value);
-        if (!neq)
-        {
-            return {};
-        }
         assert(lb->var() == ub->var());
-        assert(neq->var() == lb->var());
 
         Lra_conflict_analysis analysis{lra, lia};
-        analysis.conflict().push_back(~neq->reason().lit()); // add equality: x == value
+
+        // Collect all disallowed integer values in the interval [lb_int, ub_int].
+        // If there is any integer value that is not disallowed, there is no conflict.
+        std::vector<Constraint> neq_reasons;
+        for (Rational value = lb_int; value <= ub_int; value += 1)
+        {
+            auto neq = bounds[var_ord].inequality(models, value);
+            if (!neq)
+            {
+                return {};
+            }
+            neq_reasons.push_back(neq->reason());
+        }
+        assert(!neq_reasons.empty());
+
+        for (auto const& reason : neq_reasons)
+        {
+            assert(reason.pred() == Order_predicate::eq && reason.lit().is_negation());
+            analysis.conflict().push_back(~reason.lit()); // add equality: x == value
+        }
 
         auto fm_lb = analysis.eliminate(models, bounds, *lb);
         auto fm_ub = analysis.eliminate(models, bounds, *ub);
 
         std::vector<int> assigned_vars;
         assigned_vars.reserve(static_cast<std::size_t>(fm_lb.derived().size() + fm_ub.derived().size() +
-                                                       neq->reason().size()));
+                                                       neq_reasons.size() * 2));
         collect_assigned_vars(fm_lb, var_ord, assigned_vars);
         collect_assigned_vars(fm_ub, var_ord, assigned_vars);
-        for (auto other_var : neq->reason().vars())
+
+        for (auto const& reason : neq_reasons)
         {
-            if (other_var != var_ord && models.owned().is_defined(other_var))
+            for (auto other_var : reason.vars())
             {
-                assigned_vars.push_back(other_var);
+                if (other_var != var_ord && models.owned().is_defined(other_var))
+                {
+                    assigned_vars.push_back(other_var);
+                }
             }
         }
         std::sort(assigned_vars.begin(), assigned_vars.end());

--- a/src/lra/Lra_conflict_analysis.cpp
+++ b/src/lra/Lra_conflict_analysis.cpp
@@ -1,5 +1,4 @@
 #include "Lra_conflict_analysis.h"
-#include "Conflict_analysis.h"
 #include "Linear_arithmetic.h"
 
 #include <array>
@@ -63,12 +62,6 @@ void add_assignment_literal(Linear_arithmetic* lra, Trail& trail, Models& models
     assert(eval(models.owned(), eq) == true);
     assert(eval(models.boolean(), eq.lit()) == true);
     out.push_back(~eq.lit()); // add inequality: var != current_value
-}
-
-Clause compute_uip(Trail const& trail, Clause&& conflict)
-{
-    Conflict_analysis analysis;
-    return analysis.analyze(trail, std::move(conflict)).first;
 }
 
 } // namespace
@@ -211,13 +204,14 @@ Fm_elimination::Constraint Fm_elimination::finish(Trail& trail)
     std::sort(poly.begin(), poly.end(), [&](auto lhs, auto rhs) {
         Variable lhs_var{lhs.first, Variable::rational};
         Variable rhs_var{rhs.first, Variable::rational};
-        return trail.decision_level(lhs_var).value() > trail.decision_level(rhs_var).value();
+        return trail.decision_level(lhs_var).value_or(0) > trail.decision_level(rhs_var).value_or(0);
     });
 
     auto cons = lra->constraint(trail, std::views::keys(poly.variables),
                                 std::views::values(poly.variables), pred, -poly.constant);
     auto models = lra->relevant_models(trail);
-    if (!models.boolean().is_defined(cons.lit().var().ord()))
+    auto cons_val = eval(models.owned(), cons);
+    if (cons_val.has_value() && !models.boolean().is_defined(cons.lit().var().ord()))
     {
         lra->propagate(trail, models, cons);
     }
@@ -278,9 +272,10 @@ std::optional<Clause> Bound_conflict_analysis::analyze(Trail& trail, Bounds& bou
         auto derived = fm.finish(trail);
         if (!derived.empty())
         {
-            assert(eval(models.boolean(), derived.lit()) == false);
-            assert(eval(models.owned(), derived) == false);
-            conflict.push_back(derived.lit());
+            if (eval(models.owned(), derived) == false && eval(models.boolean(), derived.lit()) == false)
+            {
+                conflict.push_back(derived.lit());
+            }
         }
 
         assert(conflict.size() >= 2);
@@ -344,7 +339,7 @@ std::optional<Clause> Bound_conflict_analysis::analyze(Trail& trail, Bounds& bou
         auto clause = analysis.finish();
         assert(!clause.empty());
         assert(eval(models.boolean(), clause) == false);
-        return compute_uip(trail, std::move(clause));
+        return clause;
     }
 
 }
@@ -388,9 +383,10 @@ std::optional<Clause> Inequality_conflict_analysis::analyze(Trail& trail, Bounds
             auto derived = fm.finish(trail);
             if (!derived.empty())
             {
-                assert(eval(models.owned(), derived) == false);
-                assert(eval(models.boolean(), derived.lit()) == false);
-                analysis.conflict().push_back(derived.lit());
+                if (eval(models.owned(), derived) == false && eval(models.boolean(), derived.lit()) == false)
+                {
+                    analysis.conflict().push_back(derived.lit());
+                }
             }
             mult = -mult;
         }
@@ -459,7 +455,7 @@ std::optional<Clause> Inequality_conflict_analysis::analyze(Trail& trail, Bounds
         auto clause = analysis.finish();
         assert(!clause.empty());
         assert(eval(models.boolean(), clause) == false);
-        return compute_uip(trail, std::move(clause));
+        return clause;
     }
 }
 

--- a/src/lra/Lra_conflict_analysis.cpp
+++ b/src/lra/Lra_conflict_analysis.cpp
@@ -182,12 +182,11 @@ std::optional<Clause> Bound_conflict_analysis::analyze(Trail& trail, Bounds& bou
             (lb->value() + 1 < ub->value()) ||
             (lb->value() + 1 == ub->value() &&
                 (!lb->value().isInteger() ||
-                !is_strict)))
+                !lb->is_strict() || !ub->is_strict())))
         {
             return {};
         }
     }
-
 
     assert(lb->var() == ub->var());
 

--- a/src/lra/Lra_conflict_analysis.cpp
+++ b/src/lra/Lra_conflict_analysis.cpp
@@ -1,7 +1,77 @@
 #include "Lra_conflict_analysis.h"
+#include "Conflict_analysis.h"
 #include "Linear_arithmetic.h"
 
+#include <array>
+
 namespace yaga {
+
+namespace {
+
+using Models = Theory_models<Rational>;
+using Bound = Implied_value<Rational>;
+
+Rational integer_lower_bound(Bound const& lb)
+{
+    auto result = lb.value().ceil();
+    if (lb.is_strict() && lb.value().isInteger())
+    {
+        result += 1;
+    }
+    return result;
+}
+
+Rational integer_upper_bound(Bound const& ub)
+{
+    auto result = ub.value().floor();
+    if (ub.is_strict() && ub.value().isInteger())
+    {
+        result -= 1;
+    }
+    return result;
+}
+
+void collect_assigned_vars(Fm_elimination const& fm, int excluded_var, std::vector<int>& out)
+{
+    for (auto const& [var, _] : fm.derived())
+    {
+        if (var != excluded_var)
+        {
+            out.push_back(var);
+        }
+    }
+}
+
+void add_assignment_literal(Linear_arithmetic* lra, Trail& trail, Models& models, Clause& out,
+                            int var_ord)
+{
+    if (!models.owned().is_defined(var_ord))
+    {
+        return;
+    }
+
+    std::array<int, 1> vars{var_ord};
+    std::array<Rational, 1> coef{Rational{1}};
+    auto eq = lra->constraint(trail, vars, coef, Order_predicate::eq, models.owned().value(var_ord));
+
+    // Make sure the equality is assigned in the boolean model.
+    if (!models.boolean().is_defined(eq.lit().var().ord()))
+    {
+        lra->propagate(trail, models, eq);
+    }
+
+    assert(eval(models.owned(), eq) == true);
+    assert(eval(models.boolean(), eq.lit()) == true);
+    out.push_back(~eq.lit()); // add inequality: var != current_value
+}
+
+Clause compute_uip(Trail const& trail, Clause&& conflict)
+{
+    Conflict_analysis analysis;
+    return analysis.analyze(trail, std::move(conflict)).first;
+}
+
+} // namespace
 
 void Fm_elimination::init(Constraint const& cons)
 {
@@ -175,39 +245,60 @@ std::optional<Clause> Bound_conflict_analysis::analyze(Trail& trail, Bounds& bou
         {
             return {}; // no conflict
         }
-    }
-    else
-    {
-        if ((lb->value() == ub->value() && !is_strict) ||
-            (lb->value() + 1 < ub->value()) ||
-            (lb->value() + 1 == ub->value() &&
-                (!lb->value().isInteger() ||
-                !lb->is_strict() || !ub->is_strict())))
+        assert(lb->var() == ub->var());
+
+        // Derive a conflict using FM elimination. We implicitly use resolution to resolve intermediate
+        // results.
+        Lra_conflict_analysis analysis{lra, lia};
+        auto fm = analysis.eliminate(models, bounds, *lb);
+        fm.resolve(analysis.eliminate(models, bounds, *ub), ub->var());
+
+        auto& conflict = analysis.finish();
+        auto derived = fm.finish(trail);
+        if (!derived.empty())
         {
-            return {};
+            assert(eval(models.boolean(), derived.lit()) == false);
+            assert(eval(models.owned(), derived) == false);
+            conflict.push_back(derived.lit());
         }
+
+        assert(conflict.size() >= 2);
+        assert(eval(models.boolean(), conflict) == false);
+        return conflict;
     }
-
-    assert(lb->var() == ub->var());
-
-    // Derive a conflict using FM elimination. We implicitly use resolution to resolve intermediate
-    // results.
-    Lra_conflict_analysis analysis{lra, lia};
-    auto fm = analysis.eliminate(models, bounds, *lb);
-    fm.resolve(analysis.eliminate(models, bounds, *ub), ub->var());
-
-    auto& conflict = analysis.finish();
-    auto derived = fm.finish(trail);
-    if (!derived.empty())
+    else  // lia
     {
-        assert(eval(models.boolean(), derived.lit()) == false);
-        assert(eval(models.owned(), derived) == false);
-        conflict.push_back(derived.lit());
+        auto const lb_int = integer_lower_bound(*lb);
+        auto const ub_int = integer_upper_bound(*ub);
+        if (lb_int <= ub_int)
+        {
+            return {}; // there is an integer value between the bounds
+        }
+
+        // Explain the conflict by collecting constraint assumptions and equalities of all
+        // assigned variables that were used to derive the conflicting bounds.
+        Lra_conflict_analysis analysis{lra, lia};
+        auto fm_lb = analysis.eliminate(models, bounds, *lb);
+        auto fm_ub = analysis.eliminate(models, bounds, *ub);
+
+        std::vector<int> assigned_vars;
+        assigned_vars.reserve(static_cast<std::size_t>(fm_lb.derived().size() + fm_ub.derived().size()));
+        collect_assigned_vars(fm_lb, var_ord, assigned_vars);
+        collect_assigned_vars(fm_ub, var_ord, assigned_vars);
+        std::sort(assigned_vars.begin(), assigned_vars.end());
+        assigned_vars.erase(std::unique(assigned_vars.begin(), assigned_vars.end()), assigned_vars.end());
+
+        for (auto assigned_var : assigned_vars)
+        {
+            add_assignment_literal(lra, trail, models, analysis.conflict(), assigned_var);
+        }
+
+        auto clause = analysis.finish();
+        assert(!clause.empty());
+        assert(eval(models.boolean(), clause) == false);
+        return compute_uip(trail, std::move(clause));
     }
 
-    assert(conflict.size() >= 2);
-    assert(eval(models.boolean(), conflict) == false);
-    return conflict;
 }
 
 std::optional<Clause> Inequality_conflict_analysis::analyze(Trail& trail, Bounds& bounds,
@@ -228,45 +319,89 @@ std::optional<Clause> Inequality_conflict_analysis::analyze(Trail& trail, Bounds
         {
             return {};
         }
-    } else {
-        // check if there is still an integer between the bounds
-        if (lb->value() != ub->value() || lb->reason().is_strict() || ub->reason().is_strict() ||
-            !lb->value().isInteger())
+
+        // check if `x != D` where D, L, U evaluate to the same value
+        auto neq = bounds[var_ord].inequality(models, lb->value());
+        if (!neq)
         {
             return {};
         }
-    }
+        assert(lb->var() == ub->var());
+        assert(neq->var() == lb->var());
 
+        Lra_conflict_analysis analysis{lra, lia};
+        analysis.conflict().push_back(~neq->reason().lit());
 
-    // check if `x != D` where D, L, U evaluate to the same value
-    auto neq = bounds[var_ord].inequality(models, lb->value());
-    if (!neq)
-    {
-        return {};
-    }
-    assert(lb->var() == ub->var());
-    assert(neq->var() == lb->var());
-
-    Lra_conflict_analysis analysis{lra, lia};
-    analysis.conflict().push_back(~neq->reason().lit());
-
-    auto mult = neq->reason().coef().front() > 0 ? 1 : -1;
-    for (auto bound_ptr : {lb, ub})
-    {
-        auto fm = analysis.eliminate(models, bounds, *bound_ptr);
-        fm.resolve(Fm_elimination{lra, neq->reason(), Order_predicate::lt, mult}, neq->var());
-        auto derived = fm.finish(trail);
-        if (!derived.empty())
+        auto mult = neq->reason().coef().front() > 0 ? 1 : -1;
+        for (auto bound_ptr : {lb, ub})
         {
-            assert(eval(models.owned(), derived) == false);
-            assert(eval(models.boolean(), derived.lit()) == false);
-            analysis.conflict().push_back(derived.lit());
+            auto fm = analysis.eliminate(models, bounds, *bound_ptr);
+            fm.resolve(Fm_elimination{lra, neq->reason(), Order_predicate::lt, mult}, neq->var());
+            auto derived = fm.finish(trail);
+            if (!derived.empty())
+            {
+                assert(eval(models.owned(), derived) == false);
+                assert(eval(models.boolean(), derived.lit()) == false);
+                analysis.conflict().push_back(derived.lit());
+            }
+            mult = -mult;
         }
-        mult = -mult;
-    }
 
-    assert(eval(models.boolean(), analysis.conflict()) == false);
-    return analysis.finish();
+        assert(eval(models.boolean(), analysis.conflict()) == false);
+        return analysis.finish();
+    } else {  // lia
+        auto const lb_int = integer_lower_bound(*lb);
+        auto const ub_int = integer_upper_bound(*ub);
+
+        if (lb_int > ub_int)
+        {
+            return {}; // bound conflict (handled by Bound_conflict_analysis)
+        }
+        if (lb_int != ub_int)
+        {
+            return {}; // there is an integer value different from the disallowed one
+        }
+
+        auto const& value = lb_int; // the only integer value allowed by the bounds
+        auto neq = bounds[var_ord].inequality(models, value);
+        if (!neq)
+        {
+            return {};
+        }
+        assert(lb->var() == ub->var());
+        assert(neq->var() == lb->var());
+
+        Lra_conflict_analysis analysis{lra, lia};
+        analysis.conflict().push_back(~neq->reason().lit()); // add equality: x == value
+
+        auto fm_lb = analysis.eliminate(models, bounds, *lb);
+        auto fm_ub = analysis.eliminate(models, bounds, *ub);
+
+        std::vector<int> assigned_vars;
+        assigned_vars.reserve(static_cast<std::size_t>(fm_lb.derived().size() + fm_ub.derived().size() +
+                                                       neq->reason().size()));
+        collect_assigned_vars(fm_lb, var_ord, assigned_vars);
+        collect_assigned_vars(fm_ub, var_ord, assigned_vars);
+        for (auto other_var : neq->reason().vars())
+        {
+            if (other_var != var_ord && models.owned().is_defined(other_var))
+            {
+                assigned_vars.push_back(other_var);
+            }
+        }
+        std::sort(assigned_vars.begin(), assigned_vars.end());
+        assigned_vars.erase(std::unique(assigned_vars.begin(), assigned_vars.end()), assigned_vars.end());
+
+        for (auto assigned_var : assigned_vars)
+        {
+            add_assignment_literal(lra, trail, models, analysis.conflict(), assigned_var);
+        }
+
+        auto clause = analysis.finish();
+        assert(!clause.empty());
+        assert(eval(models.boolean(), clause) == false);
+        return compute_uip(trail, std::move(clause));
+    }
 }
 
 } // namespace yaga

--- a/src/lra/Lra_conflict_analysis.h
+++ b/src/lra/Lra_conflict_analysis.h
@@ -245,7 +245,7 @@ public:
     using Constraint = Linear_constraint<Rational>;
     using Polynomial = detail::Linear_polynomial<Rational>;
 
-    inline Lra_conflict_analysis(Linear_arithmetic* lra) : lra(lra) {}
+    inline Lra_conflict_analysis(Linear_arithmetic* lra, bool lia) : lra(lra), lia(lia) {}
 
     /** Eliminate a variable using @p bound
      *
@@ -274,6 +274,7 @@ public:
 private:
     Linear_arithmetic* lra;
     Clause clause;
+    bool lia;
 };
 
 /** Analysis of bound conflicts.
@@ -284,7 +285,7 @@ public:
     using Constraint = Linear_constraint<Rational>;
     using Polynomial = detail::Linear_polynomial<Rational>;
 
-    inline Bound_conflict_analysis(Linear_arithmetic* lra) : lra(lra) {}
+    inline Bound_conflict_analysis(Linear_arithmetic* lra, bool lia) : lra(lra), lia(lia) {}
 
     /** Check if there is a bound conflict and provide an explanation if there is a conflict.
      *
@@ -297,6 +298,7 @@ public:
 
 private:
     Linear_arithmetic* lra;
+    bool lia;
 };
 
 /** Analysis of inequality conflicts.
@@ -307,7 +309,7 @@ public:
     using Constraint = Linear_constraint<Rational>;
     using Polynomial = detail::Linear_polynomial<Rational>;
 
-    inline Inequality_conflict_analysis(Linear_arithmetic* lra) : lra(lra), fm(lra) {}
+    inline Inequality_conflict_analysis(Linear_arithmetic* lra, bool lia) : lra(lra), fm(lra), lia(lia) {}
 
     /** Check if there is an inequality conflict - i.e., `L <= x` and `x <= U` and `x != D`
      * where L, U, D evaluate to the same value in @p trail
@@ -322,6 +324,7 @@ public:
 private:
     Linear_arithmetic* lra;
     Fm_elimination fm;
+    bool lia;
 };
 
 } // namespace yaga

--- a/src/lra/Lra_conflict_analysis.h
+++ b/src/lra/Lra_conflict_analysis.h
@@ -126,14 +126,20 @@ public:
     using Polynomial = detail::Linear_polynomial<Rational>;
     using Variable_coefficient = std::pair<int, Rational>;
 
-    inline explicit Fm_elimination(Linear_arithmetic* lra) : lra(lra) {}
+    inline explicit Fm_elimination(Linear_arithmetic* lra, bool lia = false) : lra(lra), lia(lia)
+    {
+    }
 
     /** Create FM elimination starting with the constraint @p cons
      *
      * @param lra LRA plugin
      * @param cons linear constraint
      */
-    inline Fm_elimination(Linear_arithmetic* lra, Constraint cons) : lra(lra) { init(cons); }
+    inline Fm_elimination(Linear_arithmetic* lra, Constraint cons, bool lia = false)
+        : lra(lra), lia(lia)
+    {
+        init(cons);
+    }
 
     /** Create FM elimination starting with the polynomial of @p cons multiplied by @p mult with
      * predicate @p pred
@@ -144,8 +150,8 @@ public:
      * @param mult constant by which we multiply linear polynomial from @p cons
      */
     inline Fm_elimination(Linear_arithmetic* lra, Constraint cons, Order_predicate pred,
-                          Rational mult)
-        : lra(lra)
+                          Rational mult, bool lia = false)
+        : lra(lra), lia(lia)
     {
         init(cons, pred, mult);
     }
@@ -200,6 +206,8 @@ private:
     Order_predicate pred = Order_predicate::eq;
     // LRA plugin
     Linear_arithmetic* lra;
+    // if true, apply integer-specific strengthening when initializing inequalities
+    bool lia;
 
     /** Set current constraint to @p cons
      *
@@ -221,6 +229,12 @@ private:
      * @param mult constant by which we multiply linear polynomial from @p cons
      */
     void init(Constraint const& cons, Order_predicate pred, Rational mult);
+
+    /** Compute minimal positive step size of `derived()` for integer variables.
+     *
+     * Assumes all variables are integer.
+     */
+    [[nodiscard]] Rational integer_step() const;
 
     // check if a linear constraint implies a lower bound for a variable with coefficient `coef`
     inline bool is_lower_bound(Rational coef, Order_predicate pred, bool is_negation) const
@@ -309,7 +323,10 @@ public:
     using Constraint = Linear_constraint<Rational>;
     using Polynomial = detail::Linear_polynomial<Rational>;
 
-    inline Inequality_conflict_analysis(Linear_arithmetic* lra, bool lia) : lra(lra), fm(lra), lia(lia) {}
+    inline Inequality_conflict_analysis(Linear_arithmetic* lra, bool lia)
+        : lra(lra), fm(lra, lia), lia(lia)
+    {
+    }
 
     /** Check if there is an inequality conflict - i.e., `L <= x` and `x <= U` and `x != D`
      * where L, U, D evaluate to the same value in @p trail

--- a/src/parser/Parser_context.cpp
+++ b/src/parser/Parser_context.cpp
@@ -54,6 +54,9 @@ type_t Parser_context::get_type_for_symbol(std::string const& symbol)
     if (symbol == "Real") {
         return terms::types::real_type;
     }
+    if (symbol == "Int") {
+        return terms::types::real_type;
+    }
     throw std::logic_error("Requested unknown type");
 }
 

--- a/src/parser/Solver_wrapper.cpp
+++ b/src/parser/Solver_wrapper.cpp
@@ -1,5 +1,7 @@
 #include "Solver_wrapper.h"
 #include "utils/Utils.h"
+
+#include <algorithm>
 #include <variant>
 
 namespace yaga::parser
@@ -30,20 +32,83 @@ Solver_answer Solver_wrapper::check(std::vector<term_t> const& assertions)
     // Cnfize and assert clauses to the solver
     solver.init();
 
-    internalizer.visit(assertions);
+    // Internalize all non-trivial terms first. For top-level disjunctions (CNF clauses), avoid
+    // introducing an extra Tseitin variable and assert the clause directly.
+    std::vector<term_t> to_internalize;
+    to_internalize.reserve(assertions.size());
+    for (term_t assertion : assertions)
+    {
+        if (assertion == terms::true_term)
+        {
+            continue;
+        }
+
+        if (term_manager.get_kind(assertion) == terms::Kind::OR_TERM && !term_manager.is_negated(assertion))
+        {
+            for (term_t arg : term_manager.get_args(assertion))
+            {
+                to_internalize.push_back(arg);
+            }
+        }
+        else
+        {
+            to_internalize.push_back(assertion);
+        }
+    }
+    internalizer.visit(to_internalize);
 
     // add top level assertions to the solver
     for (term_t assertion : assertions)
     {
         if (assertion == terms::true_term) { continue; }
-        auto possibly_literal = internalizer_config.get_literal_for(term_manager.positive_term(assertion));
-        assert(possibly_literal.has_value());
-        Literal literal = possibly_literal.value();
-        if (term_manager.is_negated(assertion))
+
+        if (term_manager.get_kind(assertion) == terms::Kind::OR_TERM && !term_manager.is_negated(assertion))
         {
-            literal.negate();
+            auto args = term_manager.get_args(assertion);
+            std::vector<Literal> clause;
+            clause.reserve(args.size());
+            for (term_t arg : args)
+            {
+                auto pos_arg = term_manager.positive_term(arg);
+                auto possibly_literal = internalizer_config.get_literal_for(pos_arg);
+                assert(possibly_literal.has_value());
+                Literal lit = possibly_literal.value();
+                if (term_manager.is_negated(arg))
+                {
+                    lit.negate();
+                }
+                clause.push_back(lit);
+            }
+
+            std::sort(clause.begin(), clause.end(), Literal_comparer{});
+            clause.erase(std::unique(clause.begin(), clause.end()), clause.end());
+
+            bool tautology = false;
+            for (std::size_t i = 0; i + 1 < clause.size(); ++i)
+            {
+                if (clause[i + 1] == ~clause[i])
+                {
+                    tautology = true;
+                    break;
+                }
+            }
+
+            if (!tautology)
+            {
+                solver.assert_clause(std::move(clause));
+            }
         }
-        solver.assert_clause(literal);
+        else
+        {
+            auto possibly_literal = internalizer_config.get_literal_for(term_manager.positive_term(assertion));
+            assert(possibly_literal.has_value());
+            Literal literal = possibly_literal.value();
+            if (term_manager.is_negated(assertion))
+            {
+                literal.negate();
+            }
+            solver.assert_clause(literal);
+        }
     }
 
     // remember term-variable mapping

--- a/src/terms/Term_rewriter.h
+++ b/src/terms/Term_rewriter.h
@@ -41,7 +41,7 @@ public:
             {
                 term_t next_child = children[current_entry.next_child];
                 ++current_entry.next_child;
-                if (is_processed(next_child)) { toProcess.emplace_back(next_child); }
+                if (not is_processed(next_child)) { toProcess.emplace_back(next_child); }
                 continue;
             }
             // If we are here, we have already processed all children

--- a/src/variable_order/Generalized_vsids.cpp
+++ b/src/variable_order/Generalized_vsids.cpp
@@ -82,7 +82,14 @@ std::optional<Variable> Generalized_vsids::pick_effectively_decided(Trail& trail
     for (int var_ord : lra->effectively_decided())
     {
         Variable var{var_ord, Variable::rational};
-        effectively_decided.push(var, score(var));
+        if (effectively_decided.contains(var))
+        {
+            effectively_decided.update(var, score(var));
+        }
+        else
+        {
+            effectively_decided.push(var, score(var));
+        }
     }
 
     // decide effectively decided variables first

--- a/tests/lra/Lra_conflict_analysis_test.cpp
+++ b/tests/lra/Lra_conflict_analysis_test.cpp
@@ -186,7 +186,7 @@ TEST_CASE("Derive bound conflict when some variables are not assigned", "[bound_
         std::vector{*bounds[z.ord()].upper_bound(models)}});
     REQUIRE(bounds[x.ord()].lower_bound(models));
     
-    Bound_conflict_analysis analysis{&lra};
+    Bound_conflict_analysis analysis{&lra, false};
     auto conflict = analysis.analyze(trail, bounds, x.ord());
     REQUIRE(conflict);
     REQUIRE_THAT(*conflict, Catch::Matchers::UnorderedEquals(clause(
@@ -255,7 +255,7 @@ TEST_CASE("Derive inequality conflict when some variables are not assigned", "[i
     bounds[x.ord()].add_inequality(models, {x.ord(), 0, constraints[4], models});
     REQUIRE(bounds[x.ord()].inequality(models, 0));
 
-    Inequality_conflict_analysis analysis{&lra};
+    Inequality_conflict_analysis analysis{&lra, false};
     auto conflict = analysis.analyze(trail, bounds, x.ord());
     REQUIRE(conflict);
     REQUIRE_THAT(*conflict, Catch::Matchers::UnorderedEquals(clause(

--- a/tests/lra/Lra_conflict_analysis_test.cpp
+++ b/tests/lra/Lra_conflict_analysis_test.cpp
@@ -6,6 +6,26 @@
 #include "test.h"
 #include "Rational.h"
 
+namespace {
+
+void propagate_bool(yaga::Trail& trail, yaga::Literal lit)
+{
+    auto& model = trail.model<bool>(yaga::Variable::boolean);
+    REQUIRE(!model.is_defined(lit.var().ord()));
+    model.set_value(lit.var().ord(), !lit.is_negation());
+    trail.propagate(lit.var(), /*reason=*/nullptr, trail.decision_level());
+}
+
+void decide_rational(yaga::Trail& trail, yaga::Variable var, yaga::Rational value)
+{
+    auto& model = trail.model<yaga::Rational>(yaga::Variable::rational);
+    REQUIRE(!model.is_defined(var.ord()));
+    model.set_value(var.ord(), value);
+    trail.decide(var);
+}
+
+} // namespace
+
 TEST_CASE("FM elimination", "[fm]")
 {
     using namespace yaga;
@@ -267,4 +287,111 @@ TEST_CASE("Derive inequality conflict when some variables are not assigned", "[i
         make(c - a < -3),
         make(2 * b - 3 * c < -7)
     )));
+}
+
+TEST_CASE("Derive bound conflict in LIA when there is no integer between bounds", "[bound_conflict][lia]")
+{
+    using namespace yaga;
+    using namespace yaga::test;
+    using namespace yaga::literals;
+
+    constexpr int num_reals = 1;
+
+    Linear_arithmetic lra;
+    Event_dispatcher dispatcher;
+    dispatcher.add(&lra);
+    Trail trail{dispatcher};
+    trail.set_model<bool>(Variable::boolean, 0);
+    trail.set_model<Rational>(Variable::rational, num_reals);
+
+    Bounds bounds;
+    bounds.resize(num_reals);
+    auto [x] = real_vars<num_reals>();
+    auto make = factory(lra, trail);
+    auto models = lra.relevant_models(trail);
+
+    auto gt0 = make(x > 0);
+    auto lt1 = make(x < 1);
+    propagate_bool(trail, gt0.lit());
+    propagate_bool(trail, lt1.lit());
+
+    bounds[x.ord()].add_lower_bound(models, {x.ord(), 0, gt0, models});
+    bounds[x.ord()].add_upper_bound(models, {x.ord(), 1, lt1, models});
+
+    Bound_conflict_analysis analysis{&lra, /*lia=*/true};
+    auto conflict = analysis.analyze(trail, bounds, x.ord());
+    REQUIRE(conflict);
+    REQUIRE_THAT(*conflict, Catch::Matchers::UnorderedEquals(clause(~gt0, ~lt1)));
+}
+
+TEST_CASE("Derive bound conflict in LIA from a fractional equality", "[bound_conflict][lia]")
+{
+    using namespace yaga;
+    using namespace yaga::test;
+    using namespace yaga::literals;
+
+    constexpr int num_reals = 2;
+
+    Linear_arithmetic lra;
+    Event_dispatcher dispatcher;
+    dispatcher.add(&lra);
+    Trail trail{dispatcher};
+    trail.set_model<bool>(Variable::boolean, 0);
+    trail.set_model<Rational>(Variable::rational, num_reals);
+
+    Bounds bounds;
+    bounds.resize(num_reals);
+    auto [x, y] = real_vars<num_reals>();
+    auto make = factory(lra, trail);
+    auto models = lra.relevant_models(trail);
+
+    auto eq = make(2 * x == y);
+    propagate_bool(trail, eq.lit());
+    decide_rational(trail, y, 1);
+
+    bounds[x.ord()].add_lower_bound(models, {x.ord(), 1_r / 2, eq, models});
+    bounds[x.ord()].add_upper_bound(models, {x.ord(), 1_r / 2, eq, models});
+
+    Bound_conflict_analysis analysis{&lra, /*lia=*/true};
+    auto conflict = analysis.analyze(trail, bounds, x.ord());
+    REQUIRE(conflict);
+    REQUIRE_THAT(*conflict, Catch::Matchers::UnorderedEquals(clause(~eq, ~make(y == 1))));
+}
+
+TEST_CASE("Derive inequality conflict in LIA when the only integer value is disallowed", "[inequality_conflict][lia]")
+{
+    using namespace yaga;
+    using namespace yaga::test;
+    using namespace yaga::literals;
+
+    constexpr int num_reals = 1;
+
+    Linear_arithmetic lra;
+    Event_dispatcher dispatcher;
+    dispatcher.add(&lra);
+    Trail trail{dispatcher};
+    trail.set_model<bool>(Variable::boolean, 0);
+    trail.set_model<Rational>(Variable::rational, num_reals);
+
+    Bounds bounds;
+    bounds.resize(num_reals);
+    auto [x] = real_vars<num_reals>();
+    auto make = factory(lra, trail);
+    auto models = lra.relevant_models(trail);
+
+    auto lb = make(10 * x >= 1);
+    auto ub = make(10 * x <= 19);
+    auto neq = make(x != 1);
+    propagate_bool(trail, lb.lit());
+    propagate_bool(trail, ub.lit());
+    propagate_bool(trail, neq.lit());
+
+    bounds[x.ord()].add_lower_bound(models, {x.ord(), 1_r / 10, lb, models});
+    bounds[x.ord()].add_upper_bound(models, {x.ord(), 19_r / 10, ub, models});
+    bounds[x.ord()].add_inequality(models, {x.ord(), 1, neq, models});
+
+    Inequality_conflict_analysis analysis{&lra, /*lia=*/true};
+    auto conflict = analysis.analyze(trail, bounds, x.ord());
+    REQUIRE(conflict);
+    REQUIRE_THAT(*conflict, Catch::Matchers::UnorderedEquals(clause(~lb, ~ub, ~neq)));
 }

--- a/tests/lra/Lra_test.cpp
+++ b/tests/lra/Lra_test.cpp
@@ -151,7 +151,7 @@ TEST_CASE("Check a satisfiable LRA formula parsed from SMTLIB", "[lra][unsat][in
     std::unordered_map<terms::term_t, int> real_vars;
     std::unordered_map<terms::term_t, Literal> bool_vars;
     Yaga smt{terms::Term_manager(), std::ranges::views::all(real_vars), std::ranges::views::all(bool_vars)};
-    smt.set_logic(QF_LRA, opts);
+    smt.set_logic(logic::qf_lra, opts);
     Smtlib_parser<Direct_interpreter> parser{smt};
     parser.parse(input);
 
@@ -184,7 +184,7 @@ TEST_CASE("Check an unsatisfiable LRA formula parsed from SMTLIB", "[lra][unsat]
     std::unordered_map<terms::term_t, int> real_vars;
     std::unordered_map<terms::term_t, Literal> bool_vars;
     Yaga smt{terms::Term_manager(), std::ranges::views::all(real_vars), std::ranges::views::all(bool_vars)};
-    smt.set_logic(QF_UFLRA, opts);
+    smt.set_logic(logic::qf_uflra, opts);
     Smtlib_parser<Direct_interpreter> parser{smt};
     parser.parse(input);
 
@@ -220,4 +220,28 @@ TEST_CASE("Formula which forces the solver to generate duplicate constraints and
         REQUIRE(*test.real("z") + *test.real("y") < 0);
         REQUIRE(*test.real("z") > 0);
     }
+}
+
+TEST_CASE("Check an unsatisfiable formula in LIA", "[lia][unsat][integration]")
+{
+    Solver solver;
+    solver.trail().set_model<bool>(Variable::boolean, 0);
+    solver.trail().set_model<Rational>(Variable::rational, 1);
+    solver.set_restart_policy<No_restart>();
+    solver.set_variable_order<First_unassigned>();
+
+    auto& theories = solver.set_theory<Theory_combination>();
+    theories.add_theory<Bool_theory>();
+    auto& lia = theories.add_theory<Linear_arithmetic>();
+    Linear_arithmetic::Options lia_opts;
+    lia_opts.prop_integer = true;
+    lia.set_options(lia_opts);
+
+    auto linear = factory(lia, solver.trail());
+    auto [x] = real_vars<1>();
+    solver.db().assert_clause(clause(linear(x > 0)));
+    solver.db().assert_clause(clause(linear(x < 1)));
+
+    auto result = solver.check();
+    REQUIRE(result == Solver::Result::unsat);
 }

--- a/tests/lra/Lra_test.cpp
+++ b/tests/lra/Lra_test.cpp
@@ -151,7 +151,7 @@ TEST_CASE("Check a satisfiable LRA formula parsed from SMTLIB", "[lra][unsat][in
     std::unordered_map<terms::term_t, int> real_vars;
     std::unordered_map<terms::term_t, Literal> bool_vars;
     Yaga smt{terms::Term_manager(), std::ranges::views::all(real_vars), std::ranges::views::all(bool_vars)};
-    smt.set_logic(logic::qf_lra, opts);
+    smt.set_logic(QF_LRA, opts);
     Smtlib_parser<Direct_interpreter> parser{smt};
     parser.parse(input);
 
@@ -184,7 +184,7 @@ TEST_CASE("Check an unsatisfiable LRA formula parsed from SMTLIB", "[lra][unsat]
     std::unordered_map<terms::term_t, int> real_vars;
     std::unordered_map<terms::term_t, Literal> bool_vars;
     Yaga smt{terms::Term_manager(), std::ranges::views::all(real_vars), std::ranges::views::all(bool_vars)};
-    smt.set_logic(logic::qf_uflra, opts);
+    smt.set_logic(QF_UFLRA, opts);
     Smtlib_parser<Direct_interpreter> parser{smt};
     parser.parse(input);
 

--- a/tests/lra/Lra_test.cpp
+++ b/tests/lra/Lra_test.cpp
@@ -245,3 +245,87 @@ TEST_CASE("Check an unsatisfiable formula in LIA", "[lia][unsat][integration]")
     auto result = solver.check();
     REQUIRE(result == Solver::Result::unsat);
 }
+
+TEST_CASE("Check an unsatisfiable formula in LIA (no integer between strict bounds)",
+          "[lia][unsat][integration]")
+{
+    Solver solver;
+    solver.trail().set_model<bool>(Variable::boolean, 0);
+    solver.trail().set_model<Rational>(Variable::rational, 2);
+    solver.set_restart_policy<No_restart>();
+    solver.set_variable_order<First_unassigned>();
+
+    auto& theories = solver.set_theory<Theory_combination>();
+    theories.add_theory<Bool_theory>();
+    auto& lia = theories.add_theory<Linear_arithmetic>();
+    Linear_arithmetic::Options lia_opts;
+    lia_opts.prop_integer = true;
+    lia.set_options(lia_opts);
+
+    auto linear = factory(lia, solver.trail());
+    auto [x, y] = real_vars<2>();
+    solver.db().assert_clause(clause(linear(x < y)));
+    solver.db().assert_clause(clause(linear(y < x + 1)));
+
+    auto result = solver.check();
+    REQUIRE(result == Solver::Result::unsat);
+}
+
+TEST_CASE("Check an unsatisfiable formula in LIA (all integers in interval disallowed)",
+          "[lia][unsat][integration]")
+{
+    Solver solver;
+    solver.trail().set_model<bool>(Variable::boolean, 0);
+    solver.trail().set_model<Rational>(Variable::rational, 1);
+    solver.set_restart_policy<No_restart>();
+    solver.set_variable_order<First_unassigned>();
+
+    auto& theories = solver.set_theory<Theory_combination>();
+    theories.add_theory<Bool_theory>();
+    auto& lia = theories.add_theory<Linear_arithmetic>();
+    Linear_arithmetic::Options lia_opts;
+    lia_opts.prop_integer = true;
+    lia.set_options(lia_opts);
+
+    auto linear = factory(lia, solver.trail());
+    auto [x] = real_vars<1>();
+    solver.db().assert_clause(clause(linear(x >= 0)));
+    solver.db().assert_clause(clause(linear(x <= 2)));
+    solver.db().assert_clause(clause(linear(x != 0)));
+    solver.db().assert_clause(clause(linear(x != 1)));
+    solver.db().assert_clause(clause(linear(x != 2)));
+
+    auto result = solver.check();
+    REQUIRE(result == Solver::Result::unsat);
+}
+
+TEST_CASE("Check an unsatisfiable formula in LIA (deep bound propagation without decisions)",
+          "[lia][unsat][integration]")
+{
+    Solver solver;
+    solver.trail().set_model<bool>(Variable::boolean, 0);
+    solver.trail().set_model<Rational>(Variable::rational, 4);
+    solver.set_restart_policy<No_restart>();
+    solver.set_variable_order<First_unassigned>();
+
+    auto& theories = solver.set_theory<Theory_combination>();
+    theories.add_theory<Bool_theory>();
+    auto& lia = theories.add_theory<Linear_arithmetic>();
+    Linear_arithmetic::Options lia_opts;
+    lia_opts.prop_bounds = true;
+    lia_opts.prop_integer = true;
+    lia.set_options(lia_opts);
+
+    auto linear = factory(lia, solver.trail());
+    auto [x0, x1, x2, x3] = real_vars<4>();
+    solver.db().assert_clause(clause(linear(x0 >= 0)));
+    solver.db().assert_clause(clause(linear(x0 <= 0)));
+    solver.db().assert_clause(clause(linear(x1 >= x0 + 1)));
+    solver.db().assert_clause(clause(linear(x2 >= x1 + 1)));
+    solver.db().assert_clause(clause(linear(x3 >= x2 + 1)));
+    solver.db().assert_clause(clause(linear(x0 >= x3 + 1)));
+
+    auto result = solver.check();
+    REQUIRE(result == Solver::Result::unsat);
+    REQUIRE(solver.num_decisions() <= 1);
+}

--- a/tests/lra/Smtlib_parser_test.cpp
+++ b/tests/lra/Smtlib_parser_test.cpp
@@ -341,6 +341,38 @@ TEST_CASE("Parse linear polynomial", "[test_parser]")
     }
 }
 
+TEST_CASE("Defined function substitution (QF_LIA)", "[test_parser]")
+{
+    using namespace yaga;
+    using namespace yaga::test;
+
+    Yaga_test test;
+    test.input() << "(set-logic QF_LIA)\n";
+    test.input() << "(define-fun max ((x Int) (y Int)) Int (ite (< x y) y x))\n";
+
+    SECTION("Max is substituted and evaluated")
+    {
+        test.input() << "(declare-fun b () Int)\n";
+        test.input() << "(assert (= b (max 0 1)))\n";
+        test.run();
+
+        REQUIRE(test.answer() == Solver_answer::SAT);
+        REQUIRE(test.real("b") == Rational{1});
+    }
+
+    SECTION("Max constraints participate in UNSAT")
+    {
+        test.input() << "(declare-fun a () Int)\n";
+        test.input() << "(declare-fun b () Int)\n";
+        test.input() << "(assert (= a 178))\n";
+        test.input() << "(assert (= b (max 0 (- (+ a 13) 22))))\n";
+        test.input() << "(assert (= b 0))\n";
+        test.run();
+
+        REQUIRE(test.answer() == Solver_answer::UNSAT);
+    }
+}
+
 TEST_CASE("Parse if-then-else with real output", "[test_parser]")
 {
     using namespace yaga;

--- a/tests/test.h
+++ b/tests/test.h
@@ -370,7 +370,7 @@ private:
                     {
                         bool_model.insert({name, value.str() == "true"});
                     }
-                    else if (type == "Real")
+                    else if (type == "Real" || type == "Int")
                     {
                         lra_model.insert({name, parse_rational(value)});
                     }

--- a/tests/test.h
+++ b/tests/test.h
@@ -452,7 +452,15 @@ public:
 
         function_map_t const& fn_map = it_f->second;
         auto it = fn_map.find(args);
-        return it != fn_map.end() ? std::optional{it->second} : std::nullopt;
+        if (it != fn_map.end())
+        {
+            return it->second;
+        }
+
+        // If the argument combination is not explicitly listed, fall back to the trailing (else)
+        // value of the ite-expression.
+        auto it_else = fnc_trailing_values.find(name);
+        return it_else != fnc_trailing_values.end() ? std::optional{it_else->second} : std::nullopt;
     }
 };
 

--- a/tests/uf/Uninterpreted_functions_test.cpp
+++ b/tests/uf/Uninterpreted_functions_test.cpp
@@ -73,7 +73,7 @@ TEST_CASE("UF: propagation introduces conflict", "[uf]")
     b_map_t bm;
 
     Yaga yaga(tm, std::ranges::views::all(rm), std::ranges::views::all(bm));
-    yaga.set_logic(logic::qf_uflra, Options());
+    yaga.set_logic(QF_UFLRA, Options());
 
     Variable vx = make_real_var_for_term(tx, rm, yaga);
     Variable vfx = make_real_var_for_app_term(tfx, rm, yaga);
@@ -117,7 +117,7 @@ TEST_CASE("UF: valid function model", "[uf]")
     b_map_t bm;
 
     Yaga yaga(tm, std::ranges::views::all(rm), std::ranges::views::all(bm));
-    yaga.set_logic(logic::qf_uflra, Options());
+    yaga.set_logic(QF_UFLRA, Options());
     yaga.solver().trail().resize(Variable::rational, 3); // TODO - is it necessary?
 
     Variable vx = make_real_var_for_term(tx, rm, yaga);

--- a/tests/uf/Uninterpreted_functions_test.cpp
+++ b/tests/uf/Uninterpreted_functions_test.cpp
@@ -73,7 +73,7 @@ TEST_CASE("UF: propagation introduces conflict", "[uf]")
     b_map_t bm;
 
     Yaga yaga(tm, std::ranges::views::all(rm), std::ranges::views::all(bm));
-    yaga.set_logic(QF_UFLRA, Options());
+    yaga.set_logic(logic::qf_uflra, Options());
 
     Variable vx = make_real_var_for_term(tx, rm, yaga);
     Variable vfx = make_real_var_for_app_term(tfx, rm, yaga);
@@ -117,7 +117,7 @@ TEST_CASE("UF: valid function model", "[uf]")
     b_map_t bm;
 
     Yaga yaga(tm, std::ranges::views::all(rm), std::ranges::views::all(bm));
-    yaga.set_logic(QF_UFLRA, Options());
+    yaga.set_logic(logic::qf_uflra, Options());
     yaga.solver().trail().resize(Variable::rational, 3); // TODO - is it necessary?
 
     Variable vx = make_real_var_for_term(tx, rm, yaga);


### PR DESCRIPTION
This PR implements support of QF_LIA via the LRA plugin.

The `get-model` command is implemented in an ad-hoc manner, to be refactored. I have tested just on two inputs, so consider this WiP, until this is solved, it is not to be merged into master, yet.